### PR TITLE
images fix for chatgpt plugin tutorial

### DIFF
--- a/tutorials/chatgpt-plugin-tutorial.mdx
+++ b/tutorials/chatgpt-plugin-tutorial.mdx
@@ -56,7 +56,7 @@ You might have to try a few times before getting a good answer.
 
 Ask it to handle errors and create a Flask app with /convert and all the other endpoints necessary for a completely functional plugin.
 
-<Img src="https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/2287b21e-94f8-451f-5272-0a386df9d800/full" alt="Create a Flask app with ChatGPT" caption="Create a Flask app" />
+<Img src="https://iili.io/JJqrEs1.png" alt="Create a Flask app with ChatGPT" caption="Create a Flask app" />
 
 Here is the complete code ChatGPT gave me:
 
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 Awesome! We are now going to create a replit repo and continue working on our plugin there. [Create a replit account](https://replit.com/) if you haven't already 
 and create a new repo.
 
-<Img src="https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/475c583c-876f-452a-d1a5-56e5b11f7800/full" alt="Create replit repo" caption="Create replit repo" />
+<Img src="https://iili.io/JJqrcbV.png" alt="Create replit repo" caption="Create replit repo" />
 
 Copy the code ChatGPT just wrote into main.py file of the replit repo.
 
@@ -108,7 +108,7 @@ Copy the code ChatGPT just wrote into main.py file of the replit repo.
 
 On your replit console, open a New Tab -> Secrets and paste there your Exchange Rates API Key. 
 
-<Img src="https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/739bfbba-b621-4050-b414-24aa72caa400/full" alt="Paste Exchange Rate API Key in Replit repo" caption="Paste Exchange Rate API Key in Replit repo" />
+<Img src="https://iili.io/JJqrV0g.png" alt="Paste Exchange Rate API Key in Replit repo" caption="Paste Exchange Rate API Key in Replit repo" />
 
 Now modify the code to get the API_KEY from the repository's environment:
 
@@ -331,7 +331,7 @@ We're almost there! Go to to the ChatGPT plugin store, and click on "Develop you
 If prompted, click on the "My manifest is ready" button and give it your app's base URL `https://currency-converter-plugin.< YOUR_REPLIT_USERNAME >.repl.co`.
 Continue with the installation and you should now be able to use your plugin. Let's test it!
 
-<Img src="https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/7d802152-1b40-495c-55ab-82cdc8306a00/full" alt="ChatGPT plugin currency converter" caption="ChatGPT plugin currency converter" />
+<Img src="https://iili.io/JJqr1WP.png" alt="ChatGPT plugin currency converter" caption="ChatGPT plugin currency converter" />
 
 🥳🥳🥳
 

--- a/tutorials/chatgpt-plugin-tutorial.mdx
+++ b/tutorials/chatgpt-plugin-tutorial.mdx
@@ -157,7 +157,7 @@ Open a Shell tab on your replit console, and install waitress.
 pip install waitress
 ```
 
-<Img src="https://iili.io/HiA2yEF.png" alt="Install waitress web server" caption="Install waitress web server" />
+<Img src="https://iili.io/JJqrMqF.png" alt="Install waitress web server" caption="Install waitress web server" />
 
 Then add the following endpoints to serve our manifest and Open API definition files:
 
@@ -326,7 +326,7 @@ components:
 
 We're almost there! Go to to the ChatGPT plugin store, and click on "Develop your own plugin".
 
-<Img src="https://iili.io/HiA2pB1.png" alt="ChatGPT plugin store" caption="ChatGPT plugin store" />
+<Img src="https://iili.io/JJqrezN.png" alt="ChatGPT plugin store" caption="ChatGPT plugin store" />
 
 If prompted, click on the "My manifest is ready" button and give it your app's base URL `https://currency-converter-plugin.< YOUR_REPLIT_USERNAME >.repl.co`.
 Continue with the installation and you should now be able to use your plugin. Let's test it!


### PR DESCRIPTION

On the "Create a ChatGPT Plugin using ChatGPT" tutorial, 4 images had low resolution and 2 had broken links. This commit provides new image links to fix that.

Image links:

Line 59: https://iili.io/JJqrEs1.png
Line 103: https://iili.io/JJqrcbV.png
Line 111:  https://iili.io/JJqrV0g.png
Line 160: https://iili.io/JJqrMqF.png
Line 329: https://iili.io/JJqrezN.png
Line 334: https://iili.io/JJqr1WP.png
