### PR TITLE
Add agent skills and CLAUDE.md for content workflow

### DIFF
--- a/.agents/skills/content-start/SKILL.md
+++ b/.agents/skills/content-start/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: content-start
+description: Run the mandatory pre-writing research protocol before starting any Lablab article or tutorial. Use when about to write or draft a new article or tutorial — checks for duplicates, gathers sources, confirms the angle, and sets the Notion task to In Progress.
+compatibility: Designed for Claude Code. Requires Exa MCP, Brave Search MCP (or WebSearch fallback), and Notion API token in ~/.claude/settings.local.json.
+---
+
+## Steps
+
+### 1. Identify the piece
+
+Ask the user (if not already provided):
+- Is this an **article** or a **tutorial**?
+- What is the working title or topic?
+- Is there a Notion task already, or does one need to be created?
+
+### 2. Check Notion for an existing brief
+
+Fetch the Notion task from the Tasks & Action Items DB (`2cab4088-66ca-4d1f-aeb9-8fe29dafb470`):
+- Filter: `Workspace = Lablab`, `Category = Content`, title matches the topic
+- Read the Notes field for any brief, Slack context, angle, or contacts already captured
+- Note the current Status — if `Not Started`, it will be set to `In Progress` at the end of this skill
+
+### 3. Run the uniqueness check
+
+Search for existing content using this order:
+
+1. **Exa MCP** (`mcp__exa__*`) — semantic search for similar articles/tutorials
+2. **Brave Search MCP** (`mcp__brave__*`) — keyword search
+3. **Built-in WebSearch** — fallback if MCPs are unavailable
+
+Run these queries:
+- Exact topic title (e.g., `"AI-driven interactive charts with Claude"`)
+- Broader topic (e.g., `"Claude API data visualization tutorial"`)
+- Lablab-specific: `site:lablab.ai [topic]`
+
+**Decision:**
+- Near-identical piece exists on a major platform → flag to user. Angle must change before proceeding.
+- Similar pieces exist but shallow or outdated → note the gap we're filling, proceed.
+- Nothing close → proceed with confidence.
+
+### 4. Gather sources
+
+Search for:
+- Official docs for all tools/APIs the piece will use
+- Real-world examples and use cases
+- Recent library/API release notes that affect the content
+- Any stats or claims that need a live source (no hallucinated numbers)
+
+### 5. Confirm the angle with the user
+
+Present:
+- What exists already and how we're different
+- The proposed unique hook in one sentence
+- Target reader level: beginner / intermediate / advanced
+- Any code demos, repos, or partner links to include
+
+Wait for user confirmation before proceeding to draft.
+
+### 6. Set Notion task to In Progress
+
+Update the Notion task status to `In Progress`.
+If no task exists, create one now using the `notion-task` skill before continuing.
+
+### 7. Hand off
+
+Confirm the following are locked before writing begins:
+- [ ] Angle confirmed
+- [ ] Target reader level confirmed
+- [ ] Sources gathered
+- [ ] Notion task is `In Progress`
+- [ ] File location decided: `articles/[slug].md` or `tutorials/[slug]/article.md`
+
+## Content type reminders
+
+**Articles** (`articles/[slug].md`):
+- 800–1,500 words
+- Lead with the insight, not the setup — no "In this article..." openers
+- Clear point of view; practical takeaway at the end
+
+**Tutorials** (`tutorials/[slug]/article.md`):
+- 1,200–2,500 words
+- Structure: Introduction → Prerequisites → Steps → Conclusion
+- All code blocks complete and runnable — no `...` placeholders
+- Each step doable in under 10 minutes for an intermediate developer

--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: publish-check
+description: Run the publishing checklist for a Lablab article or tutorial before marking it as Done. Use when a draft is complete and ready to be signed off — checks all sections are written, code blocks work, images use Cloudinary, and Notion task is updated.
+compatibility: Designed for Claude Code. Requires Notion API token in ~/.claude/settings.local.json.
+---
+
+## Steps
+
+### 1. Identify the piece
+
+Ask the user (if not already clear):
+- Article or tutorial?
+- File path of the draft (e.g., `tutorials-and-articles/articles/monetize-llm-usdc-circle.md` or `tutorials-and-articles/tutorials/claude-interactive-charts/article.md`)
+- Notion task title (to find and update it)
+
+### 2. Read the draft
+
+Read the full draft file.
+
+### 3. Run the checklist
+
+#### For both articles and tutorials:
+
+- [ ] **No placeholders** — no TODOs, no `[insert X here]`, no `...` in code blocks
+- [ ] **No skeleton sections** — every H2/H3 has real prose, not just a heading
+- [ ] **Images use Cloudinary** — all image URLs are `https://res.cloudinary.com/dygkv9gam/image/upload/...` — no local paths, no hotlinked external images
+- [ ] **No unverified stats** — any numbers or claims have a linked source in the text
+- [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
+
+#### For articles only:
+
+- [ ] **800–1,500 words** — count and flag if outside range
+- [ ] **No "In this article..." opener** — first sentence leads with the idea
+- [ ] **Clear point of view** — the piece takes a stance, not just reports facts
+- [ ] **Practical takeaway at the end** — not a generic "get started today"
+- [ ] **At least one code snippet or concrete example** per technical claim
+- [ ] **File saved as** `articles/[slug].md`
+
+#### For tutorials only:
+
+- [ ] **1,200–2,500 words** — count and flag if outside range
+- [ ] **All code blocks are runnable** — no partial snippets; every block includes all imports
+- [ ] **Language declared** on every fenced code block (` ```python `, ` ```typescript `, etc.)
+- [ ] **Prerequisites section present** — tools, API keys, framework versions listed
+- [ ] **`.env` format shown** (if needed) — with placeholder values, never real keys
+- [ ] **Final output shown** — screenshot, terminal output, or demo of the working result
+- [ ] **File saved in** `tutorials/[slug]/article.md`
+
+### 4. Report results
+
+List every checklist item with a pass/fail. For any failure:
+- Quote the specific line or section that has the problem
+- Suggest the fix
+
+Do not mark the piece as done if any item fails.
+
+### 5. Update Notion
+
+Once all checklist items pass:
+- Fetch the Notion task by title from DB `2cab4088-66ca-4d1f-aeb9-8fe29dafb470`
+- Update Status → `Done`
+- Add a note to the Notes field: `Draft complete. File: [path]. Checked: [today's date].`
+
+### 6. Confirm
+
+Report: "All checks passed. Notion task '[title]' set to Done."

--- a/.agents/skills/weekly-ai-recap/SKILL.md
+++ b/.agents/skills/weekly-ai-recap/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: weekly-ai-recap
+description: Research, write, and publish the weekly "What happened in AI this week" article for Lablab. Run every Monday — searches for the past week's top AI news, writes a skimmable recap article, and produces a social post brief for Gosia/Soto. Updates the Notion task on completion.
+compatibility: Designed for Claude Code. Requires Exa MCP or Brave Search MCP (WebSearch fallback), Cloudinary for images, and Notion token in ~/.claude/settings.local.json (uses workspace automation token from ~/claude-workspace-automation/.env).
+---
+
+## Steps
+
+### 1. Confirm the publication date
+
+Ask the user (if not already clear):
+- What Monday is this for? (default: today's date)
+- Any specific stories, launches, or topics to definitely include?
+
+Derive:
+- `WEEK_END` = publication date (the Monday)
+- `WEEK_START` = 7 days prior (the previous Monday)
+- `SLUG` = `ai-news-recap-YYYY-MM-DD` (using the publication date)
+- `FILE_PATH` = `tutorials-and-articles/articles/ai-news-recap-YYYY-MM-DD.md`
+
+### 2. Check Notion for the task
+
+Fetch the matching task from DB `2cab4088-66ca-4d1f-aeb9-8fe29dafb470`:
+- Use the workspace automation token from `~/claude-workspace-automation/.env` (`NOTION_TOKEN`)
+- Filter: `Workspace = Lablab`, `Category = Content`, title contains "AI News Recap" or "AI recap"
+- If found: read the Notes field for any pre-captured story ideas or instructions
+- If not found: create a task using the `notion-task` global skill before continuing
+
+### 3. Research — find the top AI news of the week
+
+Search for major AI news from `WEEK_START` to `WEEK_END`. Run all available search tools in parallel:
+
+**Priority queries (always run):**
+- `"AI news this week" [WEEK_END date]`
+- `new AI model release [month year]`
+- `AI breakthrough announcement [month year]`
+- `major AI company update [month year]`
+- `AI funding round [month year]`
+
+**Supplementary queries (run if time allows):**
+- `OpenAI GPT announcement [month year]`
+- `Anthropic Claude update [month year]`
+- `Google Gemini news [month year]`
+- `Meta AI [month year]`
+- `open source AI model release [month year]`
+
+**Curate:** Select the **5–8 most significant stories**. Prioritise:
+1. New model releases or major version updates
+2. Big-company announcements (OpenAI, Anthropic, Google, Meta, xAI, Mistral)
+3. Genuine AI breakthroughs or research with real-world implications
+4. Significant funding / acquisitions
+5. Notable open-source releases
+
+Discard: minor blog posts, opinion pieces, redundant coverage of the same story.
+
+### 4. Write the article
+
+Write to `other-lablab-work/tutorials-and-articles/articles/ai-news-recap-YYYY-MM-DD.md`.
+
+**Format:**
+
+```markdown
+# [Story 1], [Story 2], [Story 3]
+
+*This Week in AI — [Month Day–Day, Year]*
+
+[2–3 sentence thematic intro. Capture the mood and the thread connecting this week's stories —
+not a list of headlines, but a single observation about what the week meant. Examples of the
+right register: "Three seismic shifts in one week." / "A quiet week on announcements, a loud
+one on implications." No "In this article..." openers.]
+
+## Key Takeaways
+
+- **[Company/topic]:** [1–2 sentences: what happened + the direct implication for builders or
+  the industry. Write it as if explaining to a smart friend, not a press release.]
+- **[Company/topic]:** [same]
+- **[Company/topic]:** [same]
+- [3–5 bullet points total — only the stories with a clear "so what"]
+
+---
+
+## [Thematic Section Title — groups 2–3 related stories, e.g. "The Open-Source Race" or "OpenAI vs. Everyone"]
+
+### [Story Headline]
+[2–3 sentences: what happened, why it matters, any concrete numbers. Source linked inline on
+the most important claim. End with the implication — one sentence, no hedging.]
+
+### [Story Headline]
+[same]
+
+---
+
+## [Next Thematic Section]
+
+### [Story Headline]
+[same format]
+
+### [Story Headline]
+[same format]
+
+---
+
+[Repeat thematic sections until all major stories are covered — aim for 2–3 sections of 2 stories each]
+
+---
+
+## Quick Hits
+
+- **[Company/topic]:** [One sentence. Source linked.] 
+- **[Company/topic]:** [One sentence. Source linked.]
+- **[Company/topic]:** [One sentence. Source linked.]
+- [4–6 bullet points for smaller stories that don't need a full breakdown]
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
+```
+
+**Writing rules:**
+- **Intro:** 2–3 sentences that name the theme of the week, not a summary of every story. The reader should feel oriented before they've read a single headline.
+- **Key Takeaways:** Implications, not just facts. Each bullet ends with what a developer or founder should *do* or *think* differently as a result.
+- **Section titles:** Group stories by theme (e.g. "Meta Goes Closed-Source", "AI Meets the Real World") — never just "News" or "Updates"
+- **Story write-ups:** 2–3 sentences, one inline source link on the key claim, end with the implication. No hanging "time will tell" sentences.
+- **Quick Hits:** Stories that matter but don't need context — funding rounds, minor releases, policy moves, notable tools
+- **Voice:** Direct and confident, like a smart colleague briefing you before a meeting. Not a journalist, not a hype merchant. Casual enough to be readable, precise enough to be trusted.
+- **Banned words:** "revolutionary", "game-changing", "powerful", "cutting-edge", "groundbreaking", "exciting", "innovative"
+- **Every factual claim has a source** — linked inline. No hallucinated stats; if a number can't be verified, omit it.
+- **Total word count:** 700–1,100 words. Skimmable but substantive.
+- **SEO:** The intro and Key Takeaways naturally include the major company names and "AI news [month year]" — do not force it, let coverage drive it.
+
+### 5. Produce the social post brief
+
+After the article is drafted, create a separate brief for Gosia and Soto at the bottom of the article file under a `---` separator, or as a note to the user:
+
+```
+SOCIAL POST BRIEF — [publication date]
+
+Format: Carousel (Instagram/LinkedIn)
+Post on: Same day as article publication
+
+Slide 1 — Cover: "What happened in AI this week 🧠" + date
+Slide 2–[N] — One story per slide: bold headline + 1-sentence summary
+Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
+
+Stories to cover (pick top 4–5 for carousel):
+1. [Story 1 headline]
+2. [Story 2 headline]
+3. [Story 3 headline]
+4. [Story 4 headline]
+5. [Story 5 headline]
+
+Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
+Template: Soto to create reusable carousel template for this series.
+```
+
+### 6. Run publish-check
+
+Before marking done, run the `publish-check` skill on the draft:
+- Confirm no placeholders, no skeleton sections, no unverified stats
+- Confirm word count is 600–1,000 words
+- Confirm all source links are present
+
+Fix any issues before continuing.
+
+### 7. Update Notion
+
+Once publish-check passes:
+- Set Notion task Status → `In Progress` (article written, pending publication)
+- Append to Notes: `Draft written. File: [FILE_PATH]. Social brief included. Date: [today].`
+
+### 8. Hand off
+
+Confirm to the user:
+- [ ] Article draft written at `[FILE_PATH]`
+- [ ] Social post brief produced
+- [ ] Notion task updated to In Progress
+- [ ] Publish-check passed
+
+Next steps for the user:
+1. Review the article and edit as needed
+2. Share the social brief with Gosia + Soto
+3. Publish the article on Lablab
+4. Gosia posts the carousel same day
+5. After publishing, run `publish-check` again and set Notion task → Done
+
+## Series tracking
+
+This skill is designed to repeat every Monday for the 5-week experiment (Apr 14 – May 12, 2026).
+After 5 editions, review performance data before committing to ongoing publication.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md — community-content
+
+This is the Lablab community-content repo. It contains all published articles, tutorials, technology pages, and topic pages for [lablab.ai](https://lablab.ai).
+
+---
+
+## Repo structure
+
+```
+blog/en/          — Articles (MDX)
+tutorials/        — Tutorial articles (MDX)
+technologies/     — Technology index pages
+topics/           — Topic index pages
+```
+
+## Content standards
+
+- **Frontmatter required on every file:** `title`, `description`, `image`, `authorUsername`
+- **Images must use Cloudinary:** all image URLs must be `https://res.cloudinary.com/dygkv9gam/image/upload/...` — no local paths, no hotlinked external images
+- **Cloudinary cloud name:** `dygkv9gam` (credentials in env as `CLOUDINARY_URL`)
+- **Author username:** `stevekimoi`
+- **SEO guidelines:** see `SEO_GUIDELINES.md` for keyword strategy and frontmatter formatting rules
+
+## Skills
+
+Three agent skills live in `.agents/skills/` and cover the full content lifecycle. Use them in order:
+
+| Skill | When to use |
+|-------|-------------|
+| [`content-start`](.agents/skills/content-start/SKILL.md) | Before writing any new article or tutorial — runs uniqueness check, gathers sources, confirms angle, sets Notion task to In Progress |
+| [`publish-check`](.agents/skills/publish-check/SKILL.md) | When a draft is complete — runs the full publishing checklist and updates Notion to Done |
+| [`weekly-ai-recap`](.agents/skills/weekly-ai-recap/SKILL.md) | Every Monday — researches the week's top AI news, writes the recap article, produces the social post brief |
+
+## Notion
+
+- Tasks DB: `2cab4088-66ca-4d1f-aeb9-8fe29dafb470`
+- Token: stored in `~/claude-workspace-automation/.env` as `NOTION_TOKEN`
+- Filter for content tasks: `Workspace = Lablab`, `Category = Content`
+
+## Git workflow
+
+- All new content goes on a feature branch, never directly to `main`
+- Branch naming: `add-[slug]`, `update-[slug]`, `fix-[slug]`
+- PRs target the upstream `lablab-ai/community-content` repo


### PR DESCRIPTION
## Summary

- Adds three Claude Code agent skills to `.agents/skills/` covering the full content lifecycle: `content-start` (pre-writing research), `publish-check` (pre-publish checklist), and `weekly-ai-recap` (Monday AI news digest)
- Adds `CLAUDE.md` at the repo root documenting structure, content standards, Cloudinary setup, skill usage, and git workflow

## Why

These skills were living in a separate workspace (`other-lablab-work`) but belong here — they're written specifically for the community-content repo and should travel with it so any Claude Code session opened in this repo picks them up automatically.

## Test plan

- [ ] Open a Claude Code session in this repo and confirm the three skills are recognized
- [ ] Run `content-start` before drafting a new article
- [ ] Run `publish-check` on a completed draft
- [ ] Run `weekly-ai-recap` on a Monday