### PR TITLE
Update CLAUDE.md: no Co-Authored-By lines in commits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,3 +43,4 @@ Four agent skills live in `.agents/skills/` and cover the full content lifecycle
 - All new content goes on a feature branch, never directly to `main`
 - Branch naming: `add-[slug]`, `update-[slug]`, `fix-[slug]`
 - PRs target the upstream `lablab-ai/community-content` repo
+- **No `Co-Authored-By` lines in commits** — do not add Claude Code attribution to any commit message


### PR DESCRIPTION
## Summary

- Adds a rule to the git workflow section of CLAUDE.md explicitly prohibiting `Co-Authored-By` attribution lines in commit messages

## Why

Keeps commit history clean and authorship accurate for the Lablab community-content repo.