### PR TITLE
Update AI/ML API tech page with hackathon credits and 200+ model focus

### DIFF
--- a/technologies/aiml-api/index.mdx
+++ b/technologies/aiml-api/index.mdx
@@ -1,53 +1,95 @@
 ---
 title: "AI/ML API"
-description: "The AI/ML API provides advanced features like text completion, image inference, speech-to-text, and text-to-speech with seamless integration and secure API key management."
+description: "AI/ML API provides unified access to 200+ state-of-the-art models, including Gemini, Claude, and other leading models, through a single API for text, image, and multimodal AI applications."
 ---
 
 # AI/ML API
-The AI/ML API offers a comprehensive suite of advanced AI functionalities designed to meet a variety of needs, including text completion, image inference, speech-to-text, and text-to-speech capabilities. The API is engineered for seamless integration, exceptional performance, and secure API key management, ensuring a smooth and reliable user experience. 
 
-| General  |  |
-| --- | --- |
-| Company | [AI/ML API](https://aimlapi.com/)  |
-| Repository | https://github.com/aimlapi |
-| Documentation | https://docs.aimlapi.com/ |
+AI/ML API gives developers a single endpoint to access more than 200 state-of-the-art AI models, including Gemini, Claude, and other leading foundation models, through a unified REST API. Instead of managing separate integrations for each provider, teams can experiment, build, and scale text, image, speech, and multimodal applications from one place, with one API key and consistent request/response formatting.
+
+| General | |
+|---------|--|
+| **Company** | [AI/ML API](https://aimlapi.com/) |
+| **Website** | [aimlapi.com](https://aimlapi.com/) |
+| **Documentation** | [docs.aimlapi.com](https://docs.aimlapi.com/) |
+| **GitHub** | [github.com/aimlapi](https://github.com/aimlapi) |
+| **Discord** | [AI/ML API Discord](https://discord.gg/aimlapi) |
+| **Type** | Unified AI model API platform |
+
+---
+
+## Hackathon Access
+
+AI/ML API is providing **$10 in credits** per participant, available to up to 1,000 participants. Access is activated via a promo code during signup.
+
+**Promo Code:** TBA
+
+**How to activate:**
+
+1. Register on the [AI/ML API website](https://aimlapi.com/) and choose the Startup plan
+2. Enter the promo code at checkout
+3. Access is valid for one week starting from the hackathon kickoff
+
+**Usage tips:**
+
+- Monitor your token usage. Larger models cost more per token, so test with smaller models before scaling up.
+- For technical support, visit the [AI/ML API Discord](https://discord.gg/aimlapi).
+
+**Important notes:**
+
+- Credits are provided by AI/ML API and subject to their delivery
+- Credits are limited to 1,000 participants and subject to availability
+- AI/ML API is a subscription-based service. If you do not plan to continue after the hackathon, cancel your subscription before the trial period ends to avoid charges
+- lablab.ai is not responsible for credit distribution or billing
+
+---
 
 ## Key Features
 
-* **Inference**: Effortlessly evaluate and deploy models for a range of tasks including text generation, image analysis, and more. This feature allows users to leverage the power of advanced AI to draw meaningful inferences from various data types.
-* **API Key Management**: Securely generate, manage, and monitor API keys to ensure the safety and integrity of interactions with the API. This feature provides robust security measures to protect data and operations.
-* **Broad Model Selection**: Gain access to a diverse array of models tailored to various AI applications, allowing selection of the most appropriate model for specific tasks. This extensive model library supports a wide range of functionalities to address different AI challenges.
+**200+ Models, One API**
+Access Gemini, Claude, Llama, Mistral, and hundreds of other models through a single OpenAI-compatible endpoint. Switch models by changing one field in your request.
 
-## Start building with AI/ML API
-To start using the AI/ML API, follow the detailed Quickstart guide which provides step-by-step instructions to set up the development environment and initiate the first API call. This guide is designed to help users quickly familiarize themselves with the API's capabilities and start leveraging its powerful features.
+**Multi-Modal Support**
+Text generation, image inference, speech-to-text, and text-to-speech are all available through the same API, reducing integration overhead for teams building multi-modal products.
 
-## Authentication
+**Unified API Key Management**
+Generate and manage API keys through a central dashboard. One key covers all models, with per-key usage tracking and rate limit controls.
 
-### API Key Management
-To use the AI/ML API, an API key is required. This key is essential for authenticating requests to the API. API keys can be easily generated and managed through the account dashboard, ensuring secure access to the API services.
+**Fast Iteration**
+Compare model outputs side-by-side without standing up separate integrations. Ideal for teams that need to test multiple providers during a hackathon or early-stage build.
 
-## Sending Your First Request
-After setting up the environment and obtaining an API key, proceed to send the first request. The API documentation provides detailed instructions and examples to help craft requests and understand responses, enabling full utilization of the AI/ML API's functionalities.
+---
 
-```
-Authorization: Bearer YOUR_API_KEY
+## Getting Started
 
-curl --location --globoff 'api.aimlapi.com/chat/completions' \
+```bash
+curl --location 'https://api.aimlapi.com/chat/completions' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer YOUR_API_KEY' \
 --data '{
-    "model": "gpt-3.5-turbo",
+    "model": "gpt-4o",
     "messages": [
         {
             "role": "user",
-            "content": "What's API?"
-        },
+            "content": "Hello! What can you do?"
+        }
     ],
-    "max_tokens": 512,
-    "stream": false,
-    
+    "max_tokens": 512
 }'
 ```
 
-👉 Read the documentation to find out more: https://docs.aimlapi.com/
+Replace `YOUR_API_KEY` with the key from your dashboard and swap the `model` field to use any model in the catalog.
 
+---
+
+## Resources
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.aimlapi.com/) — full API reference and model list
+- [Quickstart Guide](https://docs.aimlapi.com/quickstart) — first request in minutes
+- [Model Catalog](https://aimlapi.com/models) — browse all supported models
+- [GitHub](https://github.com/aimlapi) — SDK examples and open-source tools
+- [Discord](https://discord.gg/aimlapi) — community support


### PR DESCRIPTION
## Summary

- Rewrites the page to highlight access to 200+ models (Gemini, Claude, Llama, Mistral) through a single unified API
- Adds hackathon access section: $10 credits per participant (up to 1,000), promo code placeholder (TBA), activation steps, and subscription cancellation reminder
- Improves quickstart code example with clean curl syntax
- Adds `<TechTutorials/>` component and resource links including Discord
- Updates frontmatter description to reflect multi-model, multi-modal scope

## Test plan

- [ ] Confirm promo code is updated to real value before merge (currently TBA)
- [ ] Verify Discord invite link resolves
- [ ] Confirm `<TechTutorials/>` renders on the tech page
- [ ] Check all URLs resolve (docs, GitHub, model catalog)
- [ ] No em dashes in the content