### PR TITLE
Update Last Week in AI cover image (v2 poster)

### DIFF
--- a/blog/en/last-week-in-ai-2026-04-21.mdx
+++ b/blog/en/last-week-in-ai-2026-04-21.mdx
@@ -1,7 +1,7 @@
 ---
 title: "GPT-6 Inbound, Opus 4.7 Ships, OpenAI Targets Hackers"
 description: "Weekly AI developer news: GPT-6 is imminent, Claude Opus 4.7 ships with a 13% coding lift, and 87% of workers are bypassing AI tools. Recap, April 14–21, 2026."
-image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1776848758/lablab-static/last-week-in-ai-cover.png"
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1776852823/lablab-static/last-week-in-ai-cover-v2.png"
 authorUsername: "stevekimoi"
 ---
 


### PR DESCRIPTION
## Summary

- Uploads updated cover poster (`LABLAB_Weekly AI_News_2 (1).png`) to Cloudinary as `last-week-in-ai-cover-v2.png`
- Updates `blog/en/last-week-in-ai-2026-04-21.mdx` frontmatter `image` URL to point to the new version
- Change: poster v2 removes the date overlay from the lower-left panel for a cleaner, reusable design

## Cloudinary URL

`https://res.cloudinary.com/dygkv9gam/image/upload/v1776852823/lablab-static/last-week-in-ai-cover-v2.png`

## Test plan

- [x] Image accessible via Cloudinary secure URL
- [x] Frontmatter `image` field updated and uses `res.cloudinary.com/dygkv9gam` domain