### PR TITLE
Refactor content-ideate skill: concise SKILL.md + Notion script

### DIFF
--- a/.agents/skills/content-ideate/SKILL.md
+++ b/.agents/skills/content-ideate/SKILL.md
@@ -15,10 +15,22 @@ Accept a tweet URL/text, article URL/text, or raw idea. Fetch URLs. Extract the 
 - **Tutorial** if there's something to build; **Article** if it's a trend, comparison, or opinion.
 - Pick one reader level: Beginner / Intermediate / Advanced.
 
-### 3. Quick uniqueness check
+### 3. Deep uniqueness check
 
-- `site:lablab.ai [topic]` — already covered? Suggest a fresher angle.
-- One broader search (Medium, dev.to, Hashnode) — note the gap we're filling.
+The goal is to find an angle **no one has written yet**. Run all of these:
+
+1. `site:lablab.ai [topic]` — if covered, the angle must be meaningfully different
+2. `[topic] tutorial` — broad web search, scan top 10 results across all platforms
+3. `[topic] site:medium.com OR site:dev.to OR site:hashnode.com OR site:towardsdatascience.com`
+4. `[topic] site:youtube.com` — video coverage signals a saturated angle; find what they missed
+5. `[specific tool/API combo] tutorial [current year]` — check for recency gaps
+
+After all searches, answer:
+- What exact angles already exist? (list titles + platforms)
+- What angle is **missing entirely** — a combination of tools, a use case, or a reader level no one has addressed?
+- Is there a recency gap — old tutorials on a rapidly-changing tool?
+
+Only proceed with an angle that passes: **"I could not find this written anywhere."** If everything is covered, reframe around the gap rather than retreading existing ground.
 
 ### 4. Generate titles
 

--- a/.agents/skills/content-ideate/SKILL.md
+++ b/.agents/skills/content-ideate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: content-ideate
 description: Generate an article or tutorial concept from a source (tweet, article, or raw idea). Use when you have a piece of content or an idea and want to turn it into a lablab content concept — outputs a working title and brief ready to hand off to content-start.
-compatibility: Designed for Claude Code. Requires WebSearch or Brave Search MCP for uniqueness check, WebFetch for URL sources, and uv for the Notion script.
+compatibility: Designed for Claude Code. Requires WebSearch or Brave Search MCP for uniqueness check, WebFetch for URL sources, and python3 with requests installed.
 ---
 
 ## Steps
@@ -47,7 +47,7 @@ Wait for the user to confirm title and angle.
 Once confirmed, run:
 
 ```bash
-uv run scripts/post_to_notion.py \
+python3 scripts/post_to_notion.py \
   --title "confirmed title" \
   --type "Article" \
   --hook "hook sentence" \

--- a/.agents/skills/content-ideate/SKILL.md
+++ b/.agents/skills/content-ideate/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: content-ideate
+description: Generate an article or tutorial concept from a source (tweet, article, or raw idea). Use when you have a piece of content or an idea and want to turn it into a lablab content concept — outputs a working title and brief ready to hand off to content-start.
+compatibility: Designed for Claude Code. Requires WebSearch or Brave Search MCP for uniqueness check, WebFetch for URL sources, and uv for the Notion script.
+---
+
+## Steps
+
+### 1. Parse the source
+
+Accept a tweet URL/text, article URL/text, or raw idea. Fetch URLs. Extract the core claim, tools mentioned, and implied audience.
+
+### 2. Identify the angle
+
+- **Tutorial** if there's something to build; **Article** if it's a trend, comparison, or opinion.
+- Pick one reader level: Beginner / Intermediate / Advanced.
+
+### 3. Quick uniqueness check
+
+- `site:lablab.ai [topic]` — already covered? Suggest a fresher angle.
+- One broader search (Medium, dev.to, Hashnode) — note the gap we're filling.
+
+### 4. Generate titles
+
+Produce 3 options — beginner-friendly, outcome-focused, comparison/contrast. Avoid: "A Guide to X", "Everything About X", "The Ultimate X Tutorial".
+
+### 5. Present the brief
+
+```
+Type: [Article / Tutorial]
+Recommended title: [title]
+Alternative titles:
+  - [option 2]
+  - [option 3]
+
+Hook: [one sentence — what makes this different from what already exists]
+Target reader: [Beginner / Intermediate / Advanced]
+Angle: [2-3 sentences — what the piece covers, what the reader walks away with]
+
+Suggested file path: [blog/en/slug.mdx or tutorials/en/slug/article.mdx]
+```
+
+Wait for the user to confirm title and angle.
+
+### 6. Post to Notion
+
+Once confirmed, run:
+
+```bash
+uv run scripts/post_to_notion.py \
+  --title "confirmed title" \
+  --type "Article" \
+  --hook "hook sentence" \
+  --reader "Beginner" \
+  --angle "angle summary" \
+  --path "suggested/path.mdx"
+```
+
+Share the returned Notion URL with the user.
+
+## Gotchas
+
+- If the script exits with a 404, the database isn't shared with the integration yet. Ask the user to open the database in Notion → "..." → "Add connections" → "Claude Automation".
+- `--type` must be exactly `Article` or `Tutorial`; `--reader` must be `Beginner`, `Intermediate`, or `Advanced`.
+
+## Hand off
+
+Tell the user to run `content-start` with the confirmed title to begin the full pre-writing protocol.

--- a/.agents/skills/content-ideate/scripts/post_to_notion.py
+++ b/.agents/skills/content-ideate/scripts/post_to_notion.py
@@ -1,0 +1,77 @@
+# /// script
+# dependencies = ["requests"]
+# ///
+
+import argparse
+import os
+import re
+import sys
+
+import requests
+
+
+def load_token():
+    env_path = os.path.expanduser("~/claude-workspace-automation/.env")
+    try:
+        with open(env_path) as f:
+            for line in f:
+                m = re.match(r"^NOTION_TOKEN=(.+)$", line.strip())
+                if m:
+                    return m.group(1)
+    except FileNotFoundError:
+        sys.exit(f"Error: env file not found at {env_path}")
+    sys.exit("Error: NOTION_TOKEN not found in ~/claude-workspace-automation/.env")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a content idea entry in Notion")
+    parser.add_argument("--title", required=True, help="Confirmed article/tutorial title")
+    parser.add_argument("--type", required=True, choices=["Article", "Tutorial"])
+    parser.add_argument("--hook", required=True, help="One-sentence differentiator")
+    parser.add_argument("--reader", required=True, choices=["Beginner", "Intermediate", "Advanced"])
+    parser.add_argument("--angle", required=True, help="2-3 sentence angle summary")
+    parser.add_argument("--path", required=True, help="Suggested file path e.g. blog/en/slug.mdx")
+    args = parser.parse_args()
+
+    token = load_token()
+
+    resp = requests.post(
+        "https://api.notion.com/v1/pages",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Notion-Version": "2022-06-28",
+            "Content-Type": "application/json",
+        },
+        json={
+            "parent": {"database_id": "2c05a26f4693802c9ae3e010354b45fa"},
+            "properties": {
+                "Name": {"title": [{"text": {"content": args.title}}]}
+            },
+            "children": [
+                _para(f"Type: {args.type}"),
+                _para(f"Hook: {args.hook}"),
+                _para(f"Target reader: {args.reader}"),
+                _para(f"Angle: {args.angle}"),
+                _para(f"Suggested path: {args.path}"),
+            ],
+        },
+    )
+
+    if resp.status_code != 200:
+        data = resp.json()
+        sys.exit(f"Error {resp.status_code}: {data.get('message', resp.text)}")
+
+    page_id = resp.json()["id"].replace("-", "")
+    print(f"https://www.notion.so/{page_id}")
+
+
+def _para(text):
+    return {
+        "object": "block",
+        "type": "paragraph",
+        "paragraph": {"rich_text": [{"text": {"content": text}}]},
+    }
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/content-ideate/scripts/post_to_notion.py
+++ b/.agents/skills/content-ideate/scripts/post_to_notion.py
@@ -6,12 +6,15 @@ import argparse
 import os
 import re
 import sys
+from pathlib import Path
 
 import requests
 
 
 def load_token():
-    env_path = os.path.expanduser("~/claude-workspace-automation/.env")
+    # __file__ = .agents/skills/content-ideate/scripts/post_to_notion.py
+    # resolve up to .agents/skills/.env
+    env_path = Path(__file__).resolve().parent.parent.parent / ".env"
     try:
         with open(env_path) as f:
             for line in f:
@@ -20,7 +23,7 @@ def load_token():
                     return m.group(1)
     except FileNotFoundError:
         sys.exit(f"Error: env file not found at {env_path}")
-    sys.exit("Error: NOTION_TOKEN not found in ~/claude-workspace-automation/.env")
+    sys.exit(f"Error: NOTION_TOKEN not found in {env_path}")
 
 
 def main():
@@ -43,9 +46,10 @@ def main():
             "Content-Type": "application/json",
         },
         json={
-            "parent": {"database_id": "2c05a26f4693802c9ae3e010354b45fa"},
+            "parent": {"database_id": "2c75a26f469380c39b6ef150ebcf97c3"},
             "properties": {
-                "Name": {"title": [{"text": {"content": args.title}}]}
+                "Task Name": {"title": [{"text": {"content": args.title}}]},
+                "Status": {"status": {"name": "Idea - to approve"}},
             },
             "children": [
                 _para(f"Type: {args.type}"),

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.env
+.specstory/
+.vscode/
+.cursorindexingignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ Four agent skills live in `.agents/skills/` and cover the full content lifecycle
 
 | Skill | When to use |
 |-------|-------------|
+| [`content-ideate`](.agents/skills/content-ideate/SKILL.md) | When you have a source (tweet, article, raw idea) and want to turn it into a content concept — outputs working title + brief, hands off to content-start |
 | [`content-start`](.agents/skills/content-start/SKILL.md) | Before writing any new article or tutorial — runs uniqueness check, gathers sources, confirms angle, sets Notion task to In Progress |
 | [`publish-check`](.agents/skills/publish-check/SKILL.md) | When a draft is complete — runs the full publishing checklist and updates Notion to Done |
 | [`seo-apply`](.agents/skills/seo-apply/SKILL.md) | After a draft passes publish-check — reads this week's Notion SEO clusters and applies surgical keyword improvements without changing tone |


### PR DESCRIPTION
## Summary

- Rewrites `SKILL.md` to follow agentskills.io best practices — strips generic prose the agent already knows, keeps only lablab-specific facts and procedures
- Replaces the inline curl/JSON Notion payload with a single `uv run scripts/post_to_notion.py` command
- Adds `scripts/post_to_notion.py` — a self-contained PEP 723 script that creates a page in the lablab content ideas Notion database and returns the URL
- Registers `content-ideate` in the `CLAUDE.md` skills table

## Test plan

- [ ] Confirm `uv run .agents/skills/content-ideate/scripts/post_to_notion.py --help` outputs correct usage
- [ ] Share the Notion database with the "Claude Automation" integration, then run the skill end-to-end against a sample idea
- [ ] Verify the created Notion page contains the correct title and brief fields