### PR TITLE
seo: Gemini CLI vs Claude Code: title, description, and FAQ for comparison keywords

### DIFF
--- a/tutorials/en/gemini-cli-vs-claude-code-for-ai-hackathons.mdx
+++ b/tutorials/en/gemini-cli-vs-claude-code-for-ai-hackathons.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Gemini CLI vs Claude Code: A Practical Guide for AI Hackathons"
-description: "Learn how to use Gemini CLI and Claude Code for AI hackathons. See real-world comparisons, decision frameworks, and AI hackathon project workflows for strategic developers."
+title: "Gemini CLI vs Claude Code: Which AI Coding Agent Wins for Hackathons?"
+description: "Gemini CLI vs Claude Code: 4 real-world tests covering codebase mapping, audits, autonomous execution, and web search. Find out which wins for AI hackathons."
 image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1773143537/LabLab_Gemini_Claude_h0fopk.png"
 authorUsername: "stevekimoi"
 ---
@@ -300,6 +300,10 @@ Most developers can become productive with the basics in a single weekend, espec
 ### Are there any limitations when using these tools in time-limited hackathons?
 
 Yes. Gemini CLI is great for autonomous execution but can consume tokens quickly if you over-scope tasks, while Claude Code relies on a stable local state and can be disrupted by concurrent edits or long-running processes. In fast-paced **online AI hackathons**, keep your prompts focused, commit often, and test small, incremental changes to avoid debugging under deadline pressure.
+
+### Can I add Gemini CLI capabilities to Claude Code, or run them together in the same workflow?
+
+Gemini CLI and Claude Code are separate tools that run side-by-side rather than inside each other. You cannot install Gemini directly within Claude Code, but you can run both in separate terminal sessions and switch between them deliberately: use Gemini for wide-angle repository scans and autonomous batch operations, then hand off to Claude Code for the reasoning-heavy, interactive steps. The Hybrid Workflow section above maps the exact sequence most developers find effective for [AI hackathon projects](https://lablab.ai/event).
 
 ## Conclusion
 


### PR DESCRIPTION
## Summary

- Updates frontmatter title to target comparison search intent: "Gemini CLI vs Claude Code: Which AI Coding Agent Wins for Hackathons?"
- Rewrites description to lead with the primary keyword within the first 50 characters and hit the 150–160 character target
- Adds a new FAQ entry targeting "add gemini to claude code" and "how to use gemini like claude code" — the two zero-CTR variants from the SEO brief

## Target keywords

`gemini cli vs claude code`, `claude code vs gemini cli`, `gemini vs claude code`, `claude code vs gemini`, `how to use gemini like claude code`, `add gemini to claude code`

## Why

Six keyword variants for the same comparison sit at positions 5–17 with 6,700+ combined impressions and near-zero CTR on the lower-ranked variants. Consolidating search intent into a single optimized page should capture significantly more clicks without changing the article's content or voice.

## Test plan

- [ ] Frontmatter title contains primary keyword naturally
- [ ] Description is 150–160 characters and leads with the keyword
- [ ] New FAQ answer is accurate and does not overpromise ("you cannot install Gemini inside Claude Code")
- [ ] No em dashes introduced
- [ ] No breaking changes to article structure or code blocks