### PR TITLE
feat: Claude Code Desktop multi-sessions tutorial (April 2026 redesign)

### DIFF
--- a/tutorials/en/claude-code-desktop-multi-sessions.mdx
+++ b/tutorials/en/claude-code-desktop-multi-sessions.mdx
@@ -1,0 +1,178 @@
+---
+title: "Claude Code Desktop Multi-Sessions: How to Run Parallel Coding Agents in 2026"
+description: "Claude Code Desktop multi-session mode lets you run parallel coding agents across repos. Set up the redesigned app and manage multiple sessions in 2026."
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/PLACEHOLDER_ADD_COVER_IMAGE"
+authorUsername: "stevekimoi"
+---
+
+## Introduction
+
+The way agentic coding actually feels is not one focused session with a single AI partner. It is many things in flight at once: a refactor in one repo, a bug fix in another, a test-writing pass somewhere else, with you checking on each as results arrive. The April 2026 Claude Code Desktop redesign was built for exactly this reality.
+
+The updated desktop app introduces a persistent session sidebar, drag-and-drop pane layouts, an integrated terminal and file editor, and a rebuilt diff viewer that does not choke on large changesets. Taken together, these features shift Claude Code Desktop from a single-conversation tool into a multi-agent orchestration workspace.
+
+These capabilities matter especially for [AI hackathons](https://lablab.ai/ai-hackathons), where time pressure forces you to parallelize ruthlessly. Running a codebase audit in one session while prototyping a new feature in another is now a first-class workflow, not a workaround. If you want to practice these skills under real competitive pressure, explore [upcoming AI hackathons on LabLab.ai](https://lablab.ai/event).
+
+### What You'll Learn
+
+- How to open and manage multiple Claude Code Desktop sessions simultaneously
+- How to use the new sidebar to filter, group, and resume sessions quickly
+- How to configure the pane layout for your workflow (terminal, diff, preview, chat)
+- How to use Side Chat for parallel context without polluting your main thread
+- How Routines let you offload scheduled or event-driven tasks to Anthropic's cloud
+
+### Prerequisites
+
+- A Claude subscription: Pro, Max, Team, or Enterprise (all plans support the redesigned desktop app)
+- Claude Code Desktop installed on Mac (Linux support is available via SSH connection)
+- Familiarity with the basic Claude Code CLI workflow: opening a session, giving instructions, reviewing changes
+
+---
+
+## Step 1: Install or Update the Claude Code Desktop App
+
+If you already have Claude Code Desktop installed, open it and let it auto-update. If you are starting fresh:
+
+**macOS:**
+
+```bash
+brew install --cask claude-code
+```
+
+Or download the installer directly from [claude.com/product/claude-code](https://claude.com/product/claude-code) and run it.
+
+**Verify your version:** after launching the app, click the usage indicator in the top-right corner. If you see the session sidebar on the left side of the window, you have the redesigned version.
+
+---
+
+## Step 2: Open Multiple Sessions
+
+Each session in Claude Code Desktop maps to one Claude Code process running against a specific repository or directory.
+
+**Starting a new session:**
+
+1. Click the **+** button at the top of the session sidebar (left side of the window).
+2. When prompted, navigate to the repository or directory you want to work in.
+3. The session opens in the main panel and immediately appears in the sidebar.
+
+Repeat this for each concurrent task. There is no hard limit on simultaneous sessions; the practical constraint is your subscription's context usage, which you can monitor via the usage button at any time.
+
+**What shows in the sidebar:**
+
+Each sidebar entry shows the session name (defaulting to the repo name), its current status (running, idle, or complete), and a timestamp of the last activity. Sessions auto-archive when an associated pull request merges or closes, so the sidebar stays focused on active work.
+
+---
+
+## Step 3: Organize and Navigate Sessions
+
+With three or four sessions open, navigation becomes the main friction point. The sidebar gives you two tools to handle this.
+
+**Filtering:** Click the filter icon at the top of the sidebar to narrow the list by:
+- **Status:** show only running sessions, or only idle ones
+- **Project:** show only sessions belonging to a specific repo
+- **Environment:** separate local sessions from SSH sessions (useful if you connect to remote machines)
+
+**Grouping:** Switch the sidebar from flat list view to grouped-by-project view. All sessions for the same repository appear under a collapsible header, which is useful when you have multiple branches of the same repo in progress at once.
+
+**Switching:** Click any session in the sidebar to bring it into the main panel. The previous session keeps running in the background; nothing is paused.
+
+---
+
+## Step 4: Configure the Workspace Layout
+
+Every pane in the redesigned app is drag-and-drop. The four panes you can arrange are:
+
+| Pane | What it does |
+|---|---|
+| Chat | The main conversation with Claude |
+| Terminal | A live terminal in your session's working directory |
+| File Editor | Open, edit, and save files in-app without leaving Claude Code |
+| Diff Viewer | Browse pending changes; rebuilt for performance on large changesets |
+| Preview | Renders HTML files, PDFs, or runs a local dev server |
+
+A common setup for a hackathon session: Chat on the left (wide), Terminal bottom-left, Diff Viewer top-right, Preview bottom-right. Drag the pane headers to rearrange until it matches how you actually work.
+
+**View modes:** Use the toggle in the toolbar to switch between:
+- **Verbose:** full visibility into every tool call Claude makes (good for debugging)
+- **Normal:** balanced view with summaries of tool actions
+- **Summary:** shows only final results, no intermediate steps (good when a session is running autonomously)
+
+---
+
+## Step 5: Use Side Chat for Parallel Questions
+
+Sometimes you want to ask a quick question mid-session without that question becoming part of the permanent thread. Side Chat handles this.
+
+Open a Side Chat with **Cmd + ;** (Mac) or **Ctrl + ;** (Windows/Linux). The Side Chat panel slides in alongside your main conversation. It has read access to the main thread's context, so you can reference what Claude was just doing, but nothing you say or receive in Side Chat is written back to the main thread.
+
+This is useful for:
+- Asking Claude to explain a specific function without interrupting a longer task
+- Running a quick cost/benefit comparison on two approaches before committing to one
+- Getting a second-opinion summary from a fresh angle without derailing the active session
+
+---
+
+## Step 6: Offload Recurring Work with Routines
+
+Routines (launched in research preview alongside the desktop redesign) are saved Claude Code automations that run on Anthropic's cloud infrastructure. Your laptop does not need to be on for a Routine to run.
+
+A Routine bundles:
+- A prompt (the instruction you want Claude to execute)
+- A repository (the codebase it operates on)
+- Connectors (GitHub, Slack, or other integrations)
+- A trigger: scheduled time, API call, or GitHub event (such as a new pull request being opened)
+
+**Example Routine: auto-review every new PR**
+
+Configure a Routine that fires when a pull request opens on your main repo. Claude checks out the branch, reads the diff, and posts a structured review comment before any human reviewer sees the PR. Setup is done once in the Routines panel; after that it runs without any action from you.
+
+Routines are available from the left sidebar under the session list. Full documentation is available at [code.claude.com/docs](https://code.claude.com/docs).
+
+---
+
+## Hackathon Workflow: Three Sessions in Flight
+
+Here is a concrete multi-session pattern for a 48-hour [AI hackathon](https://lablab.ai/ai-hackathons) sprint:
+
+**Session 1: Codebase Scout (Summary mode)**
+Start a session in Verbose mode initially to map the repository, then switch to Summary so it continues analyzing in the background without demanding your attention. Check results every 20-30 minutes.
+
+**Session 2: Feature Work (Normal mode)**
+Your main development session. This one stays in Normal mode so you see what Claude is doing and can course-correct quickly. Use Side Chat here when you need to sanity-check an approach without adding noise to the main thread.
+
+**Session 3: Test Writer (Summary mode)**
+Point a third session at your test directory and give it a single instruction: "Write integration tests for everything added in the last commit." Let it run autonomously in Summary mode. Check back before your next commit.
+
+This pattern keeps you in the orchestrator seat rather than the co-pilot seat, which is the posture the redesigned app is explicitly built for.
+
+---
+
+## Frequently Asked Questions
+
+**How many sessions can I run at once in Claude Code Desktop?**
+
+There is no enforced limit on the number of simultaneous sessions. The constraint is context usage: each active session consumes tokens, and your plan has a usage ceiling. The usage button in the app shows both your session-level and account-level consumption in real time, so you can see when you are approaching a limit before it cuts off a running session.
+
+**Does Claude Code Desktop multi-session work on Windows?**
+
+As of the April 2026 redesign, the native multi-session desktop app runs on Mac. Windows users can connect to a Linux machine via SSH and use the full desktop feature set through that connection. A native Windows build has not been announced as of this writing.
+
+**What is the difference between a session and a Routine?**
+
+A session is an interactive, real-time conversation with Claude running against a local or remote repository. A Routine is a saved, automated version of a Claude Code task that runs on Anthropic's servers on a schedule or in response to an event, with no interactive back-and-forth required. You create Routines from inside the desktop app but they run independently once triggered.
+
+**Can I use Claude Code Desktop multi-session for AI hackathon projects?**
+
+Yes, and it is particularly effective in that context. The pattern of running a codebase analysis session, a feature development session, and a test-writing session simultaneously maps well onto a 24-48 hour hackathon sprint where time is the scarcest resource. All plans supported for AI hackathons (Pro, Max, Team, Enterprise) include access to the redesigned multi-session desktop app.
+
+**How do I keep the session sidebar from getting cluttered during a long hackathon?**
+
+Claude Code automatically archives sessions when their associated pull requests merge or close. For manual cleanup, right-click any session in the sidebar and select Archive. Archived sessions are not deleted; you can restore them from the Archived view if you need to revisit the history. Use the group-by-project view to collapse completed branches out of your active workspace without archiving them.
+
+---
+
+## Conclusion
+
+The Claude Code Desktop redesign is a meaningful shift in how AI coding assistance is delivered. Running claude code multiple sessions at once, each tracking a different repo or task, puts you in an orchestration role rather than a turn-by-turn conversation. Combined with Routines for off-device automation, the redesigned desktop app now covers both the interactive and the automated halves of an agentic development workflow.
+
+For the full documentation on the redesigned app and Routines, visit [code.claude.com/docs](https://code.claude.com/docs). Ready to put these skills to work in a live hackathon? Browse [global AI hackathons on LabLab.ai](https://lablab.ai/ai-hackathons) and find one that fits your stack.


### PR DESCRIPTION
## Summary

New tutorial covering the April 14, 2026 Claude Code Desktop redesign that introduced parallel multi-session support. This is a companion article to the high-traffic Gemini CLI vs Claude Code page, targeting new search queries around the redesigned desktop experience.

- Introduction: what changed and why parallel sessions matter for agentic coding
- Step 1: Install or update the desktop app
- Step 2: Open multiple sessions simultaneously
- Step 3: Organize sessions via the sidebar (filter by status, project, environment)
- Step 4: Configure the drag-and-drop workspace layout (chat, terminal, file editor, diff viewer, preview)
- Step 5: Use Side Chat (⌘+;) for parallel questions without polluting the main thread
- Step 6: Set up Routines for scheduled or event-driven automation on Anthropic's cloud
- Hackathon workflow: a 3-session parallel pattern for 24-48 hour sprints
- FAQ: 5 questions targeting long-tail keywords

## Target keywords

`claude code desktop multi session`, `claude code desktop redesign 2026`, `claude code multiple sessions at once`, `claude code desktop new features`

## Why

The Claude Code Desktop redesign was announced April 14, 2026. These search queries have no existing lablab.ai coverage. The topic directly extends the high-traffic Gemini CLI vs Claude Code article's audience.

## Before merging

- [ ] Upload a cover image to Cloudinary and replace the placeholder in the frontmatter `image` field
- [ ] Verify all technical details against the official announcement at https://claude.com/blog/claude-code-desktop-redesign
- [ ] No em dashes, no Co-Authored-By lines

## Test plan

- [ ] Frontmatter has all required fields (title, description, image, authorUsername) — image is currently a placeholder
- [ ] All links resolve (lablab.ai internal links, code.claude.com/docs)
- [ ] No broken MDX syntax
- [ ] FAQ answers are accurate to the April 2026 announcement