### PR TITLE
fix: convert markdown table to HTML syntax in agent harness

### DIFF
--- a/tutorials/en/claude-code-agent-harness-ai-hackathons.mdx
+++ b/tutorials/en/claude-code-agent-harness-ai-hackathons.mdx
@@ -43,12 +43,17 @@ export ANTHROPIC_API_KEY=your-api-key-here
 
 The repo has four files that matter:
 
-| File | Purpose |
-|---|---|
-| `stats.py` | Python utility library with 3 seeded bugs |
-| `test_stats.py` | pytest suite, 4 failures out of 6 tests at the start |
-| `CLAUDE.md` | Persistent instructions loaded into every agent session |
-| `agent.py` | The harness: drives the SDK, streams output, logs tool calls |
+<table>
+  <thead>
+    <tr><th>File</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>`stats.py`</td><td>Python utility library with 3 seeded bugs</td></tr>
+    <tr><td>`test_stats.py`</td><td>pytest suite, 4 failures out of 6 tests at the start</td></tr>
+    <tr><td>`CLAUDE.md`</td><td>Persistent instructions loaded into every agent session</td></tr>
+    <tr><td>`agent.py`</td><td>The harness: drives the SDK, streams output, logs tool calls</td></tr>
+  </tbody>
+</table>
 
 Confirm the tests are failing before you run the agent:
 


### PR DESCRIPTION
## Summary

The pipe table in `tutorials/en/claude-code-agent-harness-ai-hackathons.mdx` renders as a single collapsed line on lablab.ai. Converts it to HTML `<table>` syntax to match the rendering style used across other tutorials on the site.

## Change

- `tutorials/en/claude-code-agent-harness-ai-hackathons.mdx`: replace markdown pipe table with `<table>/<thead>/<tbody>/<tr>/<td>` markup

## Test plan

- [ ] Table renders with proper column widths and row separators on the live site
- [ ] No other content changed