### PR TITLE
feat: add demo video to agent harness

### DIFF
--- a/tutorials/en/claude-code-agent-harness-ai-hackathons.mdx
+++ b/tutorials/en/claude-code-agent-harness-ai-hackathons.mdx
@@ -30,6 +30,16 @@ A Python script (`agent.py`) that:
 
 ---
 
+## Demo
+
+Watch the agent run end-to-end: it picks up 4 failing tests, traces each bug to the source, applies the fixes, and verifies all 6 tests pass.
+
+<video controls width="100%" style={{borderRadius: "8px"}}>
+  <source src="https://res.cloudinary.com/dygkv9gam/video/upload/v1777043807/lablab-tutorials/claude-code-agent-harness-demo.mp4" type="video/mp4" />
+</video>
+
+---
+
 ## Step 1: Clone the Repo and Inspect the Project
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a demo video to `tutorials/en/claude-code-agent-harness-ai-hackathons.mdx`, placed in a new **Demo** section between Prerequisites and Step 1.

The video shows the agent running end-to-end: picking up 4 failing tests, tracing each bug, applying fixes, and verifying all 6 tests pass.

- Video hosted on Cloudinary: `res.cloudinary.com/dygkv9gam/video/upload/.../claude-code-agent-harness-demo.mp4`
- Embedded via HTML `<video>` tag with `controls` and full width

## Test plan

- [ ] Video plays inline on the tutorial page
- [ ] No other content changed