### PR TITLE
feat: This Week in AI recap — April 28, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-04-28.mdx
+++ b/blog/en/this-week-in-ai-2026-04-28.mdx
@@ -1,7 +1,7 @@
 ---
 title: "OpenAI Ships GPT-5.5, DeepSeek Drops V4, Meta Cuts 8,000 Jobs for AI"
 description: "OpenAI released GPT-5.5 with an 88.7% SWE-bench score and 60% fewer hallucinations, DeepSeek launched its V4 series with hybrid attention, and Meta announced 8,000 layoffs to fund a $115-135B AI capex push in April 2026."
-image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1/lablab-static/this-week-in-ai-cover.jpg"
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1777363119/lablab-static/this-week-in-ai-2026-04-28.png"
 authorUsername: "stevekimoi"
 ---
 
@@ -60,28 +60,3 @@ Google Cloud's CEO confirmed that [Gemini will power Apple Intelligence and a re
 ---
 
 *This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
-
----
-
-SOCIAL POST BRIEF — April 28, 2026
-
-Format: Carousel (Instagram/LinkedIn)
-Post on: Monday, April 28 (same day as article)
-
-Slide 1 — Cover: "What happened in AI this week 🧠" + April 21–27, 2026
-Slide 2 — OpenAI GPT-5.5: 88.7% SWE-bench, 60% fewer hallucinations. Live for all paid users now.
-Slide 3 — DeepSeek V4: New open-source flagship with hybrid attention + 1M token context. Raising $300M.
-Slide 4 — Meta: 8,000 layoffs. Capex doubles to $115–135B. All in on AI infrastructure.
-Slide 5 — Google + Apple: Gemini confirmed to power Siri and Apple Intelligence across all Apple devices.
-Slide 6 — Tencent Hy3: 295B-parameter open-source model. Chinese labs now ship weekly.
-Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
-
-Stories to cover (top 5 for carousel):
-1. OpenAI GPT-5.5 release
-2. DeepSeek V4 Flash and V4 Pro
-3. Meta 8,000 layoffs + $115-135B AI capex
-4. Google-Apple Gemini/Siri deal
-5. Tencent Hy3 Preview
-
-Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
-Template: Soto to create reusable carousel template for this series.

--- a/blog/en/this-week-in-ai-2026-04-28.mdx
+++ b/blog/en/this-week-in-ai-2026-04-28.mdx
@@ -1,0 +1,87 @@
+---
+title: "OpenAI Ships GPT-5.5, DeepSeek Drops V4, Meta Cuts 8,000 Jobs for AI"
+description: "OpenAI released GPT-5.5 with an 88.7% SWE-bench score and 60% fewer hallucinations, DeepSeek launched its V4 series with hybrid attention, and Meta announced 8,000 layoffs to fund a $115-135B AI capex push in April 2026."
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1/lablab-static/this-week-in-ai-cover.jpg"
+authorUsername: "stevekimoi"
+---
+
+# OpenAI Ships GPT-5.5, DeepSeek Drops V4, Meta Cuts 8,000 Jobs for AI
+
+*This Week in AI: April 21–27, 2026*
+
+This week the gap between labs shipping models and labs shipping infrastructure effectively closed. Three events on the same day made the picture clear: OpenAI's GPT-5.5 landed with hard benchmark numbers, DeepSeek released its first major open-source upgrade in a year, and Meta announced 8,000 layoffs to fund a near-doubling of AI capex. The model race is now indistinguishable from the infrastructure race.
+
+## Key Takeaways
+
+- **OpenAI:** GPT-5.5 scores 88.7% on SWE-bench and ships with 60% fewer hallucinations than GPT-5.4. If you're running evals, update your baselines now.
+- **DeepSeek:** V4 Flash and V4 Pro introduce a Hybrid Attention Architecture with a 1-million-token context window. The best open-source option just got meaningfully more capable.
+- **Meta:** 8,000 layoffs (10% of workforce) announced alongside capex guidance of $115–135B for 2026, nearly double 2025's spend. Meta is no longer hedging on AI.
+- **Google + Apple:** Gemini confirmed to power Apple Intelligence and a redesigned Siri. One deal just handed Google distribution across over a billion Apple devices.
+- **Tencent:** Hy3 Preview (295B parameters, open-source) dropped on the same day as DeepSeek V4. Chinese labs are now competing on release cadence, not just capability.
+
+---
+
+## The Model Sprint
+
+### OpenAI Releases GPT-5.5
+
+OpenAI [announced GPT-5.5](https://openai.com/index/introducing-gpt-5-5/) on April 23, describing it as better at multi-step agentic work: coding, computer use, early-stage scientific research, and document creation. The model scores 88.7% on SWE-bench and 92.4% on MMLU, with OpenAI reporting 60% fewer hallucinations compared to GPT-5.4. API pricing starts at $5 per million input tokens, with a Pro variant at $30 per million. The model is live now for Plus, Pro, Business, and Enterprise users in ChatGPT and Codex.
+
+### DeepSeek Drops V4 Flash and V4 Pro
+
+One day later, [DeepSeek unveiled V4 Flash and V4 Pro](https://www.bloomberg.com/news/articles/2026-04-24/deepseek-unveils-newest-flagship-a-year-after-ai-breakthrough), exactly one year after the V3 release that upended Silicon Valley. The new models use a Hybrid Attention Architecture designed to improve retention across long conversations, and both support a 1-million-token context window with claimed top-tier coding benchmark performance. DeepSeek is also [raising external funding for the first time](https://www.indexbox.io/blog/tencent-and-alibaba-in-talks-to-invest-in-ai-startup-deepseek/), targeting $300M at a $10B+ valuation, with Tencent and Alibaba reportedly in talks for a stake.
+
+---
+
+## Infrastructure and Alliances
+
+### Meta Cuts 8,000 Jobs and Doubles AI Spend
+
+Meta [announced 8,000 layoffs](https://www.cnbc.com/2026/04/23/meta-will-cut-10percent-of-workforce-as-it-pushes-more-into-ai.html) on April 23, representing 10% of its workforce, with cuts starting May 20. The company is also closing 6,000 open roles. Its 2026 capex guidance is now $115–135B, nearly double the $72B it spent in 2025. Zuckerberg framed the savings as direct inputs into AI infrastructure and next-generation LLM development. Meta's custom MTIA chips are already deployed in data centers, with the 450 and 500 series targeted for mass rollout by 2027.
+
+### Google Lands the Apple Intelligence Deal
+
+Google Cloud's CEO confirmed that [Gemini will power Apple Intelligence and a redesigned Siri](https://www.heygotrade.com/en/news/tesla-meta-google-capital-2026-ai-race/), running on Apple's Private Cloud Compute. For builders, this means Gemini is now the default reasoning layer across iOS and macOS at scale. Apple offloads model development; Google gains the distribution it could not win on its own.
+
+### Tencent Ships Hy3 Preview
+
+[Tencent launched Hy3 Preview](https://www.caixinglobal.com/2026-04-24/tech-brief-april-24-tencent-unveils-first-major-ai-model-update-under-new-leadership-102437622.html) on April 24, a 295-billion-parameter open-source model now running in its Yuanbao chatbot, replacing DeepSeek. The timing, releasing the same day as DeepSeek V4, signals that Chinese AI labs are treating weekly model drops as a deliberate competitive strategy, not just a product roadmap.
+
+---
+
+## Quick Hits
+
+- **Cursor raises $2B:** The AI coding tool is [in talks to raise $2 billion at a $50B+ valuation](https://www.cnbc.com/2026/04/19/cursor-ai-2-billion-funding-round.html). Developer tooling built on foundation models is now valued at frontier-lab scale.
+- **Anthropic at $800B:** Investors have reportedly offered valuations of [$800 billion](https://www.heygotrade.com/en/news/ai-mega-investments-anthropic-coreweave/), up from $350B in February, alongside the company's $100B, 10-year AWS commitment.
+- **AI energy efficiency:** Researchers [published results showing a 100x reduction in AI energy use](https://www.sciencedaily.com/releases/2026/04/260405003952.htm) by combining neural networks with symbolic reasoning. Still early-stage, but relevant if inference costs are on your roadmap.
+- **US AI legislation:** [78 chatbot-related bills](https://www.transparencycoalition.ai/news/ai-legislative-update-april24-2026) are currently active across 27 states. Consumer AI products shipping in the US now have a material compliance surface to monitor.
+- **Terafab + Intel:** Elon Musk's hardware venture Terafab [announced an AI chip partnership with Intel](https://english.cw.com.tw/article/article.action?id=4733), positioning itself as a potential challenger to NVIDIA's data center dominance.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
+
+---
+
+SOCIAL POST BRIEF — April 28, 2026
+
+Format: Carousel (Instagram/LinkedIn)
+Post on: Monday, April 28 (same day as article)
+
+Slide 1 — Cover: "What happened in AI this week 🧠" + April 21–27, 2026
+Slide 2 — OpenAI GPT-5.5: 88.7% SWE-bench, 60% fewer hallucinations. Live for all paid users now.
+Slide 3 — DeepSeek V4: New open-source flagship with hybrid attention + 1M token context. Raising $300M.
+Slide 4 — Meta: 8,000 layoffs. Capex doubles to $115–135B. All in on AI infrastructure.
+Slide 5 — Google + Apple: Gemini confirmed to power Siri and Apple Intelligence across all Apple devices.
+Slide 6 — Tencent Hy3: 295B-parameter open-source model. Chinese labs now ship weekly.
+Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
+
+Stories to cover (top 5 for carousel):
+1. OpenAI GPT-5.5 release
+2. DeepSeek V4 Flash and V4 Pro
+3. Meta 8,000 layoffs + $115-135B AI capex
+4. Google-Apple Gemini/Siri deal
+5. Tencent Hy3 Preview
+
+Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
+Template: Soto to create reusable carousel template for this series.


### PR DESCRIPTION
## Summary

- Adds the weekly AI news recap for April 21–27, 2026, publishing on Monday April 28
- Covers 5 major stories: OpenAI GPT-5.5, DeepSeek V4 Flash/Pro, Meta 8k layoffs + $115-135B capex, Google-Apple Gemini/Siri deal, Tencent Hy3 Preview
- Includes 5 Quick Hits: Cursor $2B raise, Anthropic $800B valuation, AI energy efficiency research, US chatbot legislation, Terafab + Intel chip deal
- Social post brief for Gosia/Soto included at the bottom of the file

## Test plan

- [ ] Review article at `blog/en/this-week-in-ai-2026-04-28.mdx`
- [ ] Confirm all inline source links are live
- [ ] Confirm frontmatter is complete (title, description, image, authorUsername)
- [ ] Share social brief with Gosia + Soto before Monday
- [ ] Merge and publish on April 28