### PR TITLE
feat: Lablab Hackathon Success Stories (Part 1)

### DIFF
--- a/blog/en/lablab-hackathon-success-stories-part-1.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-1.mdx
@@ -1,0 +1,68 @@
+---
+title: "Lablab Hackathon Success Stories (Part 1): Markster, First Concepts, BuFi, VortexIQ and Mugafi"
+description: "Five AI startups that went from lablab hackathon submissions to funded, growing companies. Meet Markster, First Concepts, BuFi, VortexIQ, and Mugafi and what happened after demo day."
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1773329376/LabLab_Hackathon_to_Reality_n8p1hn.png"
+authorUsername: "stevekimoi"
+---
+
+Five teams walked into lablab hackathons with ideas and no guarantees. They left with prototypes. Months later, the results speak for themselves: one raised $3 million and landed a Forbes Top 200 spot, one secured 500 Global backing with revenue nearly doubling in the same year, another won a Microsoft accelerator slot, and two raised pre-seed rounds from top VCs. These are their stories.
+
+## Markster: Revenue Doubled, Clients Tripled, Same Team
+
+Ivan Ivanka saw the same problem everywhere he looked: service businesses running on scattered tools, manual follow-ups, and founders acting as their own sales rep, head of marketing, and customer success manager all at once.
+
+At lablab.ai's $1M Startup Challenge with Surge in February 2026, held in San Francisco, he built a solution in one week. Markster runs a complete growth system for service businesses, handling personalized outbound across email, LinkedIn, and phone, producing content that compounds over time, and tracking every lead so nothing slips. No junior staff, no lock-in. Founders keep their data if they leave.
+
+The judges backed it. 500 Global backed it shortly after.
+
+Revenue grew from $443K to $900K. Client count went from 8 to 27 per year. Lead response time dropped from a range of 2 to 6 hours down to under 60 seconds. The team did not change.
+
+[Markster](https://markster.ai/)
+
+## Mugafi: Bollywood's AI Co-Writer
+
+Vipul Agarwal saw a gap that India's entertainment industry had been ignoring: one of the largest storytelling ecosystems in the world with almost no dedicated infrastructure for the writers who feed it. Mugafi came out of the Gaia hackathon on lablab.ai, pitching VED, an AI co-writer built specifically for Indian screenwriters.
+
+VED helps writers brainstorm, develop character arcs, structure plots, and write dialogue calibrated to Indian cinematic styles. The platform has grown to over 150,000 users, 50,000 active writers, and partnerships with 200+ industry mentors. Partners include Dharma Productions, Applause Entertainment, Reliance Entertainment, and Amazon Prime Video.
+
+Mugafi raised $3 million in seed funding, was named in Forbes Top 200 select companies, ranked in Google's Top 20 AI startups, and was showcased at Cannes for AI in Entertainment.
+
+[Mugafi](https://mugafi.com/)
+
+## VortexIQ: Agentic OS for E-Commerce
+
+Susant Patro's team built a zero-code agent builder at RAISE Your Hack 2025, a 6,000-person global hackathon co-organized by lablab.ai at the RAISE Summit in Paris, and won the Vultr track out of 922 teams.
+
+VortexIQ is now the agentic operating system for e-commerce, giving online retailers a single platform that monitors performance in real time, diagnoses issues, and deploys AI agents to fix them. Clients including Nvidia, Krispy Kreme, and British Airways are seeing up to 35% revenue gains and 50% faster problem resolution.
+
+After RAISE Your Hack, VortexIQ raised $1.05 million from Sure Valley Ventures and the Techstars London cohort, was selected as one of 12 startups for Microsoft's UK GenAI Accelerator, and became an Elite Technology Partner with BigCommerce.
+
+[VortexIQ](https://vortexiq.ai/)
+
+## First Concepts: AI Memory for Creative Agencies
+
+Conor Hoey, Polina Sali, and Marin Godechot built Liora at the Internet of Agents Hackathon by Coral Protocol and Solana on lablab.ai in September 2025. The hackathon brought together more than 3,000 developers and delivered $100,000 in prizes across agent development categories.
+
+The product evolved into First Concepts, an AI-native workspace for creative agencies. The core insight: the biggest time sink in agency work is not ideation, it is context loss. Every handoff between brief, references, and final delivery loses something. First Concepts gives teams a shared memory that holds the brief, the client's taste, and the creative direction in one place, connected across Figma, Midjourney, Kling, and whatever other tools the team uses.
+
+Agencies report up to 70% faster time-to-concept. First Concepts raised $1 million in pre-seed funding from Araya Ventures and Antler, won the AWS startup competition at Upscale Conf, and now works with 40+ creative agencies including Mother and R/GA across London and New York.
+
+[First Concepts](https://firstconcepts.co/)
+
+## BuFi: AI-Native Finance for Founders and Teams
+
+BuFi came out of the AI Agents on Arc with USDC hackathon hosted by lablab.ai in New York in late 2025, bringing together builders working at the intersection of AI agents and stablecoin payments. After the hackathon, BuFi received a grant from Circle.
+
+The product treats finance the way modern teams actually work: shared workspaces for individuals and teams, fiat and crypto in the same account, automated invoicing, payments by QR code or link, and a virtual card that spends in any currency. The AI layer handles the operational load, so founders can focus on the business instead of chasing cash flow.
+
+[BuFi](https://bu.finance/)
+
+## What These Five Share
+
+None of these teams waited until the product was finished. None had a guaranteed funding path before they showed up. What they had was a problem worth solving and a structured week to prove it in front of real judges.
+
+A hackathon compresses the validation cycle. You build, you demo, you get direct feedback from people with real experience in the space. If the idea holds under that pressure, it tends to hold in the market too.
+
+Markster, Mugafi, VortexIQ, First Concepts, and BuFi all came through lablab hackathons. All five are now live companies with paying customers or funded operations. The pattern is not coincidental.
+
+If you are building something, the next lablab hackathon may be the clearest path to finding out whether it works. Upcoming events are at [lablab.ai/events](https://lablab.ai/events).

--- a/blog/en/lablab-hackathon-success-stories-part-1.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-1.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Lablab Hackathon Success Stories (Part 1): Markster, First Concepts, BuFi, VortexIQ and Mugafi"
-description: "Five AI startups that went from lablab hackathon submissions to funded, growing companies. Meet Markster, First Concepts, BuFi, VortexIQ, and Mugafi and what happened after demo day."
+title: "AI Hackathon Success Stories (Part 1): Markster, First Concepts, BuFi, VortexIQ and Mugafi"
+description: "AI hackathon success stories: 5 startups that turned lablab submissions into funded companies. Markster, First Concepts, BuFi, VortexIQ, Mugafi."
 image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1773329376/LabLab_Hackathon_to_Reality_n8p1hn.png"
 authorUsername: "stevekimoi"
 ---
@@ -65,4 +65,4 @@ A hackathon compresses the validation cycle. You build, you demo, you get direct
 
 Markster, Mugafi, VortexIQ, First Concepts, and BuFi all came through lablab hackathons. All five are now live companies with paying customers or funded operations. The pattern is not coincidental.
 
-If you are building something, the next lablab hackathon may be the clearest path to finding out whether it works. Upcoming events are at [lablab.ai/events](https://lablab.ai/events).
+If you are building something, the next lablab hackathon may be the clearest path to finding out whether it works. Browse [upcoming AI hackathons](https://lablab.ai/events) and find your room.

--- a/blog/en/lablab-hackathon-success-stories-part-1.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-1.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AI Hackathon Success Stories (Part 1): Markster, First Concepts, BuFi, VortexIQ and Mugafi"
 description: "AI hackathon success stories: 5 startups that turned lablab submissions into funded companies. Markster, First Concepts, BuFi, VortexIQ, Mugafi."
-image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1773329376/LabLab_Hackathon_to_Reality_n8p1hn.png"
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/3801a09d-3a8f-49ed-15ea-30145e734200/public"
 authorUsername: "stevekimoi"
 ---
 


### PR DESCRIPTION
## Summary

- Adds new article covering 5 startups that came through lablab hackathons and went on to raise funding and grow real businesses
- Covers Markster (500 Global, \$443K→\$900K revenue), Mugafi (\$3M raised, Forbes Top 200), VortexIQ (RAISE Your Hack winner, \$1.05M raised), First Concepts (\$1M pre-seed, Coral Protocol hackathon), and BuFi (Circle grant, Arc NYC Hackathon)
- 941 words, Cloudflare Images cover image, no em dashes, no marketing language

## Test plan

- [x] Frontmatter fields present: title, description, image, authorUsername
- [x] Cover image uses Cloudflare Images URL (imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/...)
- [x] No em dashes in body or frontmatter
- [x] All 5 company website links are valid
- [x] Word count within 800-1,500 range
- [x] No placeholder text or skeleton sections