### PR TITLE
feat: add AMD provider technology section

### DIFF
--- a/technologies/amd/amd-developer-cloud.mdx
+++ b/technologies/amd/amd-developer-cloud.mdx
@@ -1,0 +1,50 @@
+---
+title: "AMD Developer Cloud"
+author: "AMD"
+description: "AMD Developer Cloud provides on-demand access to AMD Instinct MI300X GPUs in the cloud for AI training, fine-tuning, and inference without managing hardware."
+---
+
+# AMD Developer Cloud
+
+AMD Developer Cloud is a cloud-based GPU platform that gives developers on-demand access to AMD Instinct accelerators. It is designed for AI researchers, engineers, and builders who need high-memory GPU compute for training, fine-tuning, and inference without managing physical hardware. Members of the AMD AI Developer Program receive $100 in credits to start building immediately.
+
+| General | |
+|---------|--|
+| **Author** | [AMD](https://www.amd.com) |
+| **Type** | Cloud GPU Platform |
+| **Access** | [AMD AI Developer Program](https://www.amd.com/en/developer/developer-program.html) |
+| **Documentation** | [AMD Developer Cloud Overview](https://www.amd.com/en/developer/resources/rocm-hub/amd-developer-cloud.html) |
+| **Hardware** | AMD Instinct MI300X (192GB HBM3) |
+| **Pricing** | $100 credits for Developer Program members; pay-as-you-go available |
+
+## Start building with AMD Developer Cloud
+
+AMD Developer Cloud lets you access AMD Instinct MI300X GPUs through a simple cloud interface, so you can focus entirely on building rather than configuring infrastructure. The MI300X features 192GB of HBM3 memory, making it practical for running 70B+ parameter models on a single instance without model parallelism. Sign up for the AMD AI Developer Program to claim your credits and start running workloads today. Explore what the community has already built on AMD at [AMD Use Cases and Applications](/apps/tech/amd).
+
+### AMD Developer Cloud Tutorials
+<TechTutorials/>
+
+---
+
+### Getting Started
+
+- [AMD AI Developer Program](https://www.amd.com/en/developer/developer-program.html) Sign up to access $100 in cloud credits and AMD Instinct GPU instances
+- [AMD Developer Cloud Overview](https://www.amd.com/en/developer/resources/rocm-hub/amd-developer-cloud.html) Platform documentation and getting started guide
+- [ROCm Documentation](https://rocm.docs.amd.com/) Software stack reference for running AI workloads on AMD GPUs
+- [From Zero to AI Builder with AMD](https://www.amd.com/en/developer/resources/rocm-hub.html) Free training courses and hands-on labs with real GPU access
+
+---
+
+### Key Use Cases
+
+**Fine-tuning LLMs**
+Use AMD Instinct MI300X instances to fine-tune open-source models such as Llama, DeepSeek, Mistral, and Qwen using PyTorch and ROCm. Hugging Face Optimum-AMD provides optimized training pipelines for AMD hardware.
+
+**Large model inference**
+The MI300X's 192GB HBM3 memory capacity supports running very large models on a single GPU, reducing the need for multi-GPU serving setups.
+
+**Benchmarking and prototyping**
+Test AI workloads on AMD hardware before moving to on-premises infrastructure. The pay-as-you-go pricing keeps experimentation costs low.
+
+**Hackathon development**
+During AMD-sponsored hackathons on lablab.ai, participants receive cloud credits to access AMD GPUs directly through AMD Developer Cloud. Explore [upcoming AI hackathons](https://lablab.ai/events) to find events using AMD infrastructure.

--- a/technologies/amd/amd-rocm.mdx
+++ b/technologies/amd/amd-rocm.mdx
@@ -1,0 +1,57 @@
+---
+title: "ROCm"
+author: "AMD"
+description: "ROCm is AMD's open-source GPU computing platform supporting PyTorch, TensorFlow, and JAX for AI training, inference, and HPC workloads on AMD Instinct hardware."
+---
+
+# ROCm
+
+ROCm (Radeon Open Compute) is AMD's open-source software platform for GPU-accelerated computing. It is the AMD equivalent of NVIDIA's CUDA and provides a complete stack for running AI, machine learning, and HPC workloads on AMD GPUs. ROCm supports major ML frameworks including PyTorch, TensorFlow, JAX, and ONNX Runtime, and includes the HIP (Heterogeneous-compute Interface for Portability) programming model for writing GPU code that runs on both AMD and NVIDIA hardware.
+
+| General | |
+|---------|--|
+| **Author** | [AMD](https://www.amd.com) |
+| **Type** | Open-source GPU Computing Platform |
+| **Documentation** | [ROCm Docs](https://rocm.docs.amd.com/) |
+| **Repository** | [github.com/ROCm](https://github.com/ROCm) |
+| **Installation** | [ROCm Installation Guide](https://rocm.docs.amd.com/en/latest/deploy/linux/index.html) |
+| **Current Version** | ROCm 7 |
+| **License** | MIT and Apache 2.0 |
+
+## Start building with ROCm
+
+ROCm gives you a complete software stack to run AI training and inference workloads on AMD GPUs. It integrates directly with PyTorch, TensorFlow, and JAX so most standard pipelines run with minimal changes from a CUDA environment. Hugging Face Optimum-AMD and vLLM both support ROCm, making it straightforward to run transformer inference and fine-tuning jobs on AMD hardware. Check out the community-built [AMD Use Cases and Applications](/apps/tech/amd) to see what developers are running on ROCm today.
+
+### ROCm Tutorials
+<TechTutorials/>
+
+---
+
+### Documentation and Resources
+
+- [ROCm Documentation](https://rocm.docs.amd.com/) Full reference for installation, APIs, and libraries
+- [ROCm Installation Guide](https://rocm.docs.amd.com/en/latest/deploy/linux/index.html) Step-by-step setup for supported Linux distributions
+- [ROCm GitHub](https://github.com/ROCm) Open-source repositories, examples, and issue tracking
+- [HIP SDK](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html) SDK for writing portable GPU code for both AMD and NVIDIA hardware
+- [AMD Developer Hub](https://www.amd.com/en/developer/resources/rocm-hub.html) Guides, training videos, and cloud credits
+
+---
+
+### Framework Support
+
+- **PyTorch** Full support for training and inference, including integration with Hugging Face Accelerate and PEFT
+- **TensorFlow** GPU-accelerated training and inference on AMD hardware
+- **JAX** Supported via the ROCm JAX build
+- **ONNX Runtime** Cross-framework model deployment on AMD GPUs
+- **Hugging Face Optimum-AMD** Optimized inference and fine-tuning pipelines for transformer models
+- **vLLM** High-throughput LLM serving with a ROCm backend
+
+---
+
+### Libraries
+
+- [hipBLAS](https://github.com/ROCm/hipBLAS) BLAS implementation for AMD GPUs
+- [MIOpen](https://github.com/ROCm/MIOpen) Deep learning primitives library for AMD GPUs
+- [rocRAND](https://github.com/ROCm/rocRAND) Random number generation for AMD hardware
+- [hipSPARSE](https://github.com/ROCm/hipSPARSE) Sparse matrix operations on AMD GPUs
+- [rocBLAS](https://github.com/ROCm/rocBLAS) BLAS implementation optimized for AMD Instinct accelerators

--- a/technologies/amd/index.mdx
+++ b/technologies/amd/index.mdx
@@ -1,0 +1,55 @@
+---
+title: "AMD"
+description: "Advanced Micro Devices builds CPUs, GPUs, and open-source AI software (ROCm) that power LLM training, inference, and HPC workloads on Instinct accelerators."
+---
+
+# AMD
+
+Advanced Micro Devices (AMD) is a global semiconductor company that designs CPUs, GPUs, and accelerators for data centers, PCs, and embedded systems. Founded in 1969, AMD has built a significant AI infrastructure position through its AMD Instinct GPU line and the open-source ROCm software stack, which together serve as an alternative to proprietary GPU ecosystems for large-scale AI development.
+
+| General | |
+|---------|--|
+| **Company** | [Advanced Micro Devices, Inc.](https://www.amd.com) |
+| **Founded** | 1969 |
+| **Headquarters** | Santa Clara, California, USA |
+| **Website** | [amd.com](https://www.amd.com) |
+| **Documentation** | [ROCm Docs](https://rocm.docs.amd.com/) |
+| **GitHub** | [github.com/ROCm](https://github.com/ROCm) |
+| **Developer Hub** | [AMD ROCm Developer Hub](https://www.amd.com/en/developer/resources/rocm-hub.html) |
+| **Type** | Semiconductor / AI Infrastructure |
+
+---
+
+## Start building with AMD products
+
+AMD provides cloud-based GPU access, open-source software tooling, and developer resources for building AI applications at scale. Whether you are training a custom model, running large-scale inference, or benchmarking AI workloads, AMD's infrastructure stack gives you the compute and software you need without proprietary lock-in. Explore what the community has built on AMD by checking out [AMD Use Cases and Applications](/apps/tech/amd).
+
+---
+
+## AMD Developer Cloud
+
+The AMD Developer Cloud offers on-demand access to AMD Instinct GPUs through the cloud. It allows developers to spin up powerful GPU environments in minutes and focus on building and testing AI workloads without infrastructure overhead. Members of the AMD AI Developer Program receive $100 in cloud credits to get started.
+
+For setup details, credit access, and tutorials, see our [AMD Developer Cloud tech page](/tech/amd/amd-developer-cloud).
+
+---
+
+## ROCm
+
+ROCm (Radeon Open Compute) is AMD's open-source software platform for GPU computing — the AMD equivalent of NVIDIA's CUDA. It supports PyTorch, TensorFlow, JAX, and ONNX Runtime and integrates with Hugging Face Optimum-AMD and vLLM for serving large language models on AMD hardware.
+
+For framework support, installation guides, and libraries, see our [ROCm tech page](/tech/amd/amd-rocm).
+
+---
+
+## AMD Instinct GPU Accelerators
+
+The AMD Instinct series are data center GPUs built for AI training and inference at scale. The MI300X is based on the CDNA 3 architecture and supports up to 192GB of HBM3 memory, making it well-suited for large language model inference where memory capacity is a bottleneck. The MI325X extends this to 288GB of HBM3E memory.
+
+### Helpful Links
+
+- [ROCm Documentation](https://rocm.docs.amd.com/): full reference for installation, APIs, and libraries
+- [GitHub: ROCm](https://github.com/ROCm): open-source repos, examples, and issue tracking
+- [AMD Developer Hub](https://www.amd.com/en/developer/resources/rocm-hub.html): guides, training videos, and cloud credits
+- [HIP SDK](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html): SDK for Windows GPU development
+- [Instinct Accelerators](https://www.amd.com/en/products/accelerators/instinct.html): hardware specs and product pages


### PR DESCRIPTION
## Summary

- Adds AMD as a full provider section under `technologies/amd/`
- `index.mdx`: company overview (AMD Instinct GPUs, ROCm, Developer Cloud) with links to sub-pages
- `amd-developer-cloud.mdx`: AMD Developer Cloud — MI300X GPU access, $100 credits, use cases (fine-tuning, inference, hackathons)
- `amd-rocm.mdx`: ROCm open-source GPU computing platform — framework support (PyTorch, TF, JAX, Optimum-AMD, vLLM), libraries, install guides

Content references technologies featured in the AMD Developer Hackathon on lablab.ai.

## Test plan

- [ ] Verify all three pages render correctly on the tech section
- [ ] Check internal links from `index.mdx` to sub-pages resolve
- [ ] Confirm `<TechTutorials/>` component is present on sub-pages