### PR TITLE
feat: add Hugging Face provider technology section

### DIFF
--- a/technologies/huggingface/huggingface-hub.mdx
+++ b/technologies/huggingface/huggingface-hub.mdx
@@ -1,0 +1,64 @@
+---
+title: "Hugging Face Hub"
+author: "Hugging Face"
+description: "Hugging Face Hub is the central repository for 1M+ open-source models, datasets, and Spaces that developers can access, fine-tune, and deploy for any AI use case."
+---
+
+# Hugging Face Hub
+
+The Hugging Face Hub is an open-source repository platform that hosts over one million machine learning models, datasets, and interactive applications. It serves as the central collaboration layer for the ML community, enabling developers to discover, share, version, and deploy models across every modality including text, vision, audio, and multimodal. Model checkpoints on the Hub are compatible with the Transformers, Diffusers, and Datasets libraries, and can be loaded in a few lines of code.
+
+| General | |
+|---------|--|
+| **Author** | [Hugging Face](https://huggingface.co) |
+| **Type** | ML Model Repository and Collaboration Platform |
+| **Website** | [huggingface.co](https://huggingface.co) |
+| **Documentation** | [Hub Documentation](https://huggingface.co/docs/hub) |
+| **Repository** | [github.com/huggingface/huggingface_hub](https://github.com/huggingface/huggingface_hub) |
+| **Models** | [huggingface.co/models](https://huggingface.co/models) |
+| **Datasets** | [huggingface.co/datasets](https://huggingface.co/datasets) |
+
+## Start building with Hugging Face Hub
+
+The Hub is the fastest way to get a pretrained model running in your project. Load any of the 1M+ checkpoints directly into Transformers or Diffusers with a single function call, or browse the Hub to find the right base model for your use case. You can host your own models privately and share fine-tuned adapters with the community without uploading full model weights. During AMD-sponsored hackathons on lablab.ai, participants pull models from the Hub, fine-tune or build on them using AMD Developer Cloud GPUs, and publish their final projects back to the Hub as a Space. Explore what the community has built at [Hugging Face Use Cases and Applications](/apps/tech/huggingface).
+
+### Hugging Face Hub Tutorials
+<TechTutorials/>
+
+---
+
+### Getting Started
+
+- [Hub Documentation](https://huggingface.co/docs/hub) Full reference for model cards, repos, and the Hub API
+- [huggingface_hub Python library](https://github.com/huggingface/huggingface_hub) Python SDK for interacting with the Hub programmatically
+- [Model Hub](https://huggingface.co/models) Browse all publicly available models by task, framework, and license
+- [Datasets Hub](https://huggingface.co/datasets) Browse curated datasets for training and evaluation
+
+---
+
+### Key Features
+
+**1M+ models**
+Text, vision, audio, multimodal, and specialized domain models from top research teams and companies including Meta, Mistral, Google, and Alibaba Cloud.
+
+**Private repositories**
+Host proprietary models and datasets with access controls. Upgrade to a PRO or Enterprise account for private inference endpoints.
+
+**Model cards**
+Structured documentation for model limitations, intended use, training details, and evaluation results — standardized across all public checkpoints.
+
+**Version control**
+Git-based versioning with LFS support for large files. Every model and dataset on the Hub has a full commit history.
+
+**Fine-tuned adapters**
+Share and reuse LoRA and PEFT adapters without uploading full model weights. Adapters reference their base model and load in seconds.
+
+---
+
+### Libraries
+
+- [Transformers](https://github.com/huggingface/transformers) Unified API for pretrained models across text, vision, and audio
+- [huggingface_hub](https://github.com/huggingface/huggingface_hub) Python SDK for Hub authentication, uploads, and downloads
+- [Datasets](https://github.com/huggingface/datasets) Efficient access to Hub datasets with streaming and arrow-based caching
+- [PEFT](https://github.com/huggingface/peft) Parameter-efficient fine-tuning (LoRA, QLoRA, prefix tuning)
+- [Optimum-AMD](https://github.com/huggingface/optimum-amd) Optimized inference and training for AMD hardware via ROCm

--- a/technologies/huggingface/huggingface-spaces.mdx
+++ b/technologies/huggingface/huggingface-spaces.mdx
@@ -1,0 +1,61 @@
+---
+title: "Hugging Face Spaces"
+author: "Hugging Face"
+description: "Hugging Face Spaces lets developers build and host interactive AI demos using Gradio or Streamlit on Hugging Face infrastructure, with free CPU and paid GPU-backed tiers."
+---
+
+# Hugging Face Spaces
+
+Hugging Face Spaces is a hosting platform for interactive machine learning applications. Developers build demos and tools using Gradio or Streamlit, then deploy them on Hugging Face infrastructure and receive a public URL. Spaces are free to run on shared CPU instances and can be upgraded to GPU-backed hardware for workloads that need faster inference. They are widely used during hackathons and AI events to share working prototypes without managing any server infrastructure.
+
+| General | |
+|---------|--|
+| **Author** | [Hugging Face](https://huggingface.co) |
+| **Type** | AI Application Hosting Platform |
+| **Website** | [huggingface.co/spaces](https://huggingface.co/spaces) |
+| **Documentation** | [Spaces Documentation](https://huggingface.co/docs/hub/spaces-overview) |
+| **Hardware Options** | CPU (free), T4, A10G, A100, H100 |
+| **Frameworks** | Gradio, Streamlit, Docker |
+
+## Start building with Hugging Face Spaces
+
+Spaces is the quickest path from a working model to a shareable demo. Connect a model from the Hub, wrap it in a Gradio interface, and push to a Space — the application goes live with a public URL in minutes. GPU instances are available on an hourly basis for workloads that need real compute. During hackathons on lablab.ai, submitting a Hugging Face Space link is a standard way to present a working project. Spaces created under an event's Hugging Face organization are publicly discoverable, and community members can vote with likes. Explore examples at [Hugging Face Use Cases and Applications](/apps/tech/huggingface).
+
+### Hugging Face Spaces Tutorials
+<TechTutorials/>
+
+---
+
+### Getting Started
+
+- [Spaces Overview](https://huggingface.co/docs/hub/spaces-overview) How to create, configure, and deploy a Space
+- [Gradio Documentation](https://www.gradio.app/docs) Build interactive UIs for ML models with minimal code
+- [Streamlit Documentation](https://docs.streamlit.io/) Alternative framework for building data and ML apps
+- [Spaces GPU Instances](https://huggingface.co/docs/hub/spaces-gpus) Upgrade a Space to GPU-backed hardware for faster inference
+- [Docker Spaces](https://huggingface.co/docs/hub/spaces-sdks-docker) Deploy any containerized application as a Space
+
+---
+
+### Key Features
+
+**Instant deployment**
+Push a Gradio or Streamlit app to a Space repository and get a live URL without any server configuration or DevOps setup.
+
+**GPU hardware tiers**
+Upgrade to T4, A10G, A100, or H100 instances for workloads that need GPU acceleration. Pricing is hourly with no long-term commitment.
+
+**Organization Spaces**
+Create Spaces under a team or event organization so project submissions stay grouped and discoverable by judges and community members.
+
+**Persistent storage**
+Attach a storage volume to a Space for stateful applications that need to read or write files between requests.
+
+**Community discovery**
+Spaces are publicly indexed on Hugging Face and sortable by likes, making them a practical way to share and showcase AI projects.
+
+---
+
+### Boilerplates
+
+- [Gradio Chatbot Template](https://huggingface.co/new-space?template=gradio/chatbot) Starter Space for building a conversational AI interface
+- [Streamlit App Template](https://huggingface.co/new-space?template=streamlit/streamlit-hello) Starter Space for data and model visualization apps

--- a/technologies/huggingface/index.mdx
+++ b/technologies/huggingface/index.mdx
@@ -1,0 +1,62 @@
+---
+title: "Hugging Face"
+description: "Hugging Face is the open-source AI platform hosting 1M+ models, datasets, and Spaces, with libraries like Transformers and Diffusers used by millions of developers."
+---
+
+# Hugging Face
+
+Hugging Face, Inc. is an AI company founded in 2016 by Clément Delangue, Julien Chaumond, and Thomas Wolf in New York City. Originally launched as a chatbot application, it pivoted to become the central open-source platform for the machine learning community. The Hub now hosts over one million models, datasets, and interactive applications, and the Transformers library has become the de facto standard for working with modern neural networks.
+
+| General | |
+|---------|--|
+| **Company** | [Hugging Face, Inc.](https://huggingface.co) |
+| **Founded** | 2016 by Clément Delangue, Julien Chaumond, and Thomas Wolf |
+| **Headquarters** | New York, NY, USA |
+| **Website** | [huggingface.co](https://huggingface.co) |
+| **Documentation** | [huggingface.co/docs](https://huggingface.co/docs) |
+| **GitHub** | [github.com/huggingface](https://github.com/huggingface) |
+| **Type** | AI Platform / Open-source ML Community |
+
+---
+
+## Start building with Hugging Face products
+
+Hugging Face provides the model hub, deployment infrastructure, and open-source libraries that make up the standard developer workflow for modern AI applications. Whether you are loading a pretrained model, publishing a demo, or managing training data, Hugging Face has a product for each stage of the process. Explore what the community has built at [Hugging Face Use Cases and Applications](/apps/tech/huggingface).
+
+---
+
+## Hugging Face Hub
+
+The Hugging Face Hub is a collaborative repository for models, datasets, and applications. Developers can host, version, and share any model type, including LLMs, diffusion models, embeddings, and classifiers. The Hub supports private and public repos, fine-tuned model versions, and model cards that document intended use and limitations.
+
+For API reference, SDK documentation, and getting started resources, see our [Hugging Face Hub tech page](/tech/huggingface/huggingface-hub).
+
+---
+
+## Hugging Face Spaces
+
+Spaces lets developers build and host interactive ML applications directly on Hugging Face infrastructure. Most Spaces are built with Gradio or Streamlit and connect to models from the Hub. Spaces can be deployed on free shared CPU instances or upgraded to GPU-backed hardware for faster inference.
+
+For deployment guides, GPU tiers, and examples, see our [Hugging Face Spaces tech page](/tech/huggingface/huggingface-spaces).
+
+---
+
+## Transformers
+
+The Transformers library is the most widely used open-source library for working with pretrained neural network models. It provides a unified API for loading, running, and fine-tuning models across text, vision, audio, and multimodal tasks.
+
+## Diffusers
+
+Diffusers is the Hugging Face library for diffusion models, supporting image, video, and audio generation. It provides pipelines for Stable Diffusion, FLUX, and other generative models with a consistent API for sampling and fine-tuning.
+
+## Datasets
+
+The Datasets library provides efficient access to thousands of curated datasets hosted on the Hub. It handles streaming, caching, and preprocessing for large-scale training data and integrates directly with Transformers training pipelines.
+
+### Helpful Links
+
+- [Documentation](https://huggingface.co/docs): full reference for all libraries and the Hub API
+- [GitHub: huggingface](https://github.com/huggingface): Transformers, Diffusers, Datasets, and more
+- [Inference Providers](https://huggingface.co/docs/inference-providers/index): API access and pricing
+- [Community Forum](https://discuss.huggingface.co): questions, troubleshooting, and model discussion
+- [Hugging Face Pricing](https://huggingface.co/pricing): free tier and PRO plan details


### PR DESCRIPTION
## Summary

- Adds Hugging Face as a full provider section under `technologies/huggingface/`
- `index.mdx`: company overview (Hub, Spaces, Transformers, Diffusers, Datasets) with links to sub-pages
- `huggingface-hub.mdx`: Hugging Face Hub — 1M+ models, private repos, adapters, Python SDK, Optimum-AMD cross-reference
- `huggingface-spaces.mdx`: Hugging Face Spaces — Gradio/Streamlit hosting, GPU hardware tiers, organization Spaces for hackathon submissions

Content references Hugging Face's role as a technology partner in the AMD Developer Hackathon on lablab.ai.

## Test plan

- [ ] Verify all three pages render correctly on the tech section
- [ ] Check internal links from `index.mdx` to sub-pages resolve
- [ ] Confirm `<TechTutorials/>` component is present on sub-pages