### PR TITLE
feat: add AMD Developer Cloud technology page

### DIFF
--- a/technologies/amd/amd-developer-cloud.mdx
+++ b/technologies/amd/amd-developer-cloud.mdx
@@ -1,0 +1,50 @@
+---
+title: "AMD Developer Cloud"
+author: "AMD"
+description: "AMD Developer Cloud provides on-demand access to AMD Instinct MI300X GPUs in the cloud for AI training, fine-tuning, and inference without managing hardware."
+---
+
+# AMD Developer Cloud
+
+AMD Developer Cloud is a cloud-based GPU platform that gives developers on-demand access to AMD Instinct accelerators. It is designed for AI researchers, engineers, and builders who need high-memory GPU compute for training, fine-tuning, and inference without managing physical hardware. Members of the AMD AI Developer Program receive $100 in credits to start building immediately.
+
+| General | |
+|---------|--|
+| **Author** | [AMD](https://www.amd.com) |
+| **Type** | Cloud GPU Platform |
+| **Access** | [AMD AI Developer Program](https://www.amd.com/en/developer/developer-program.html) |
+| **Documentation** | [AMD Developer Cloud Overview](https://www.amd.com/en/developer/resources/rocm-hub/amd-developer-cloud.html) |
+| **Hardware** | AMD Instinct MI300X (192GB HBM3) |
+| **Pricing** | $100 credits for Developer Program members; pay-as-you-go available |
+
+## Start building with AMD Developer Cloud
+
+AMD Developer Cloud lets you access AMD Instinct MI300X GPUs through a simple cloud interface, so you can focus entirely on building rather than configuring infrastructure. The MI300X features 192GB of HBM3 memory, making it practical for running 70B+ parameter models on a single instance without model parallelism. Sign up for the AMD AI Developer Program to claim your credits and start running workloads today. Explore what the community has already built on AMD at [AMD Use Cases and Applications](/apps/tech/amd).
+
+### AMD Developer Cloud Tutorials
+<TechTutorials/>
+
+---
+
+### Getting Started
+
+- [AMD AI Developer Program](https://www.amd.com/en/developer/developer-program.html) Sign up to access $100 in cloud credits and AMD Instinct GPU instances
+- [AMD Developer Cloud Overview](https://www.amd.com/en/developer/resources/rocm-hub/amd-developer-cloud.html) Platform documentation and getting started guide
+- [ROCm Documentation](https://rocm.docs.amd.com/) Software stack reference for running AI workloads on AMD GPUs
+- [From Zero to AI Builder with AMD](https://www.amd.com/en/developer/resources/rocm-hub.html) Free training courses and hands-on labs with real GPU access
+
+---
+
+### Key Use Cases
+
+**Fine-tuning LLMs**
+Use AMD Instinct MI300X instances to fine-tune open-source models such as Llama, DeepSeek, Mistral, and Qwen using PyTorch and ROCm. Hugging Face Optimum-AMD provides optimized training pipelines for AMD hardware.
+
+**Large model inference**
+The MI300X's 192GB HBM3 memory capacity supports running very large models on a single GPU, reducing the need for multi-GPU serving setups.
+
+**Benchmarking and prototyping**
+Test AI workloads on AMD hardware before moving to on-premises infrastructure. The pay-as-you-go pricing keeps experimentation costs low.
+
+**Hackathon development**
+During AMD-sponsored hackathons on lablab.ai, participants receive cloud credits to access AMD GPUs directly through AMD Developer Cloud. Explore [upcoming AI hackathons](https://lablab.ai/events) to find events using AMD infrastructure.


### PR DESCRIPTION
## Summary

- Adds `technologies/amd/amd-developer-cloud.mdx`
- Covers AMD Developer Cloud: MI300X GPU access, $100 credits for AMD AI Developer Program members, pay-as-you-go pricing, use cases (fine-tuning, inference, benchmarking, hackathons)

## Test plan

- [ ] Page renders correctly under `/tech/amd/amd-developer-cloud`
- [ ] `<TechTutorials/>` component present
- [ ] All external links are valid