### PR TITLE
feat: add provider section and sub-page links to AMD index

### DIFF
--- a/technologies/amd/index.mdx
+++ b/technologies/amd/index.mdx
@@ -20,6 +20,12 @@ Advanced Micro Devices (AMD) is a global semiconductor company that designs CPUs
 
 ---
 
+## Start building with AMD products
+
+AMD provides cloud-based GPU access, open-source software tooling, and developer resources for building AI applications at scale. Whether you are training a custom model, running large-scale inference, or benchmarking AI workloads, AMD's infrastructure stack gives you the compute and software you need without proprietary lock-in. Explore what the community has built on AMD by checking out [AMD Use Cases and Applications](/apps/tech/amd).
+
+---
+
 ## Core Products
 
 ### AMD Instinct GPU Accelerators
@@ -30,6 +36,8 @@ The AMD Instinct series are data center GPUs built for AI training and inference
 
 ROCm is AMD's open-source software platform for GPU-accelerated computing. It supports HIP, OpenCL, and OpenMP programming interfaces and integrates with major ML frameworks including PyTorch, TensorFlow, and JAX. ROCm 7 is the current version, engineered for generative AI and HPC workloads with expanded hardware compatibility and new development tools.
 
+For framework support, installation guides, and libraries, see our [ROCm tech page](/tech/amd/amd-rocm).
+
 ### HIP SDK
 
 The AMD HIP (Heterogeneous-compute Interface for Portability) SDK allows developers to write GPU-accelerated code that runs on AMD hardware. HIP code is also designed to be portable to CUDA, lowering the barrier for developers migrating workloads from other GPU platforms.
@@ -37,6 +45,8 @@ The AMD HIP (Heterogeneous-compute Interface for Portability) SDK allows develop
 ### AMD Developer Cloud
 
 AMD provides a cloud environment where developers can access AMD Instinct GPU hardware for testing and benchmarking, along with free credits, training materials, and community support.
+
+For setup details, credit access, and tutorials, see our [AMD Developer Cloud tech page](/tech/amd/amd-developer-cloud).
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates `technologies/amd/index.mdx`
- Adds "Start building with AMD products" intro section
- Adds links to `amd-developer-cloud` and `amd-rocm` sub-pages within their respective product descriptions

## Test plan

- [ ] Internal links to sub-pages resolve correctly
- [ ] Page renders without breaking existing content