### PR TITLE
feat: add Hugging Face Spaces technology page

### DIFF
--- a/technologies/huggingface/huggingface-spaces.mdx
+++ b/technologies/huggingface/huggingface-spaces.mdx
@@ -1,0 +1,61 @@
+---
+title: "Hugging Face Spaces"
+author: "Hugging Face"
+description: "Hugging Face Spaces lets developers build and host interactive AI demos using Gradio or Streamlit on Hugging Face infrastructure, with free CPU and paid GPU-backed tiers."
+---
+
+# Hugging Face Spaces
+
+Hugging Face Spaces is a hosting platform for interactive machine learning applications. Developers build demos and tools using Gradio or Streamlit, then deploy them on Hugging Face infrastructure and receive a public URL. Spaces are free to run on shared CPU instances and can be upgraded to GPU-backed hardware for workloads that need faster inference. They are widely used during hackathons and AI events to share working prototypes without managing any server infrastructure.
+
+| General | |
+|---------|--|
+| **Author** | [Hugging Face](https://huggingface.co) |
+| **Type** | AI Application Hosting Platform |
+| **Website** | [huggingface.co/spaces](https://huggingface.co/spaces) |
+| **Documentation** | [Spaces Documentation](https://huggingface.co/docs/hub/spaces-overview) |
+| **Hardware Options** | CPU (free), T4, A10G, A100, H100 |
+| **Frameworks** | Gradio, Streamlit, Docker |
+
+## Start building with Hugging Face Spaces
+
+Spaces is the quickest path from a working model to a shareable demo. Connect a model from the Hub, wrap it in a Gradio interface, and push to a Space — the application goes live with a public URL in minutes. GPU instances are available on an hourly basis for workloads that need real compute. During hackathons on lablab.ai, submitting a Hugging Face Space link is a standard way to present a working project. Spaces created under an event's Hugging Face organization are publicly discoverable, and community members can vote with likes. Explore examples at [Hugging Face Use Cases and Applications](/apps/tech/huggingface).
+
+### Hugging Face Spaces Tutorials
+<TechTutorials/>
+
+---
+
+### Getting Started
+
+- [Spaces Overview](https://huggingface.co/docs/hub/spaces-overview) How to create, configure, and deploy a Space
+- [Gradio Documentation](https://www.gradio.app/docs) Build interactive UIs for ML models with minimal code
+- [Streamlit Documentation](https://docs.streamlit.io/) Alternative framework for building data and ML apps
+- [Spaces GPU Instances](https://huggingface.co/docs/hub/spaces-gpus) Upgrade a Space to GPU-backed hardware for faster inference
+- [Docker Spaces](https://huggingface.co/docs/hub/spaces-sdks-docker) Deploy any containerized application as a Space
+
+---
+
+### Key Features
+
+**Instant deployment**
+Push a Gradio or Streamlit app to a Space repository and get a live URL without any server configuration or DevOps setup.
+
+**GPU hardware tiers**
+Upgrade to T4, A10G, A100, or H100 instances for workloads that need GPU acceleration. Pricing is hourly with no long-term commitment.
+
+**Organization Spaces**
+Create Spaces under a team or event organization so project submissions stay grouped and discoverable by judges and community members.
+
+**Persistent storage**
+Attach a storage volume to a Space for stateful applications that need to read or write files between requests.
+
+**Community discovery**
+Spaces are publicly indexed on Hugging Face and sortable by likes, making them a practical way to share and showcase AI projects.
+
+---
+
+### Boilerplates
+
+- [Gradio Chatbot Template](https://huggingface.co/new-space?template=gradio/chatbot) Starter Space for building a conversational AI interface
+- [Streamlit App Template](https://huggingface.co/new-space?template=streamlit/streamlit-hello) Starter Space for data and model visualization apps

--- a/technologies/huggingface/huggingface-spaces.mdx
+++ b/technologies/huggingface/huggingface-spaces.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Hugging Face Spaces"
 author: "Hugging Face"
+authorUsername: "stevekimoi"
 description: "Hugging Face Spaces lets developers build and host interactive AI demos using Gradio or Streamlit on Hugging Face infrastructure, with free CPU and paid GPU-backed tiers."
 ---
 


### PR DESCRIPTION
## Summary

- Adds `technologies/huggingface/huggingface-spaces.mdx`
- Covers Hugging Face Spaces: Gradio/Streamlit hosting, GPU hardware tiers, organization Spaces for hackathon submissions, persistent storage, community discovery

## Test plan

- [ ] Page renders correctly under `/tech/huggingface/huggingface-spaces`
- [ ] `<TechTutorials/>` component present
- [ ] All external links are valid