### PR TITLE
feat: add provider section and sub-page links to Hugging Face index

### DIFF
--- a/technologies/huggingface/index.mdx
+++ b/technologies/huggingface/index.mdx
@@ -19,11 +19,19 @@ Hugging Face, Inc. is an AI company founded in 2016 by Clément Delangue, Julien
 
 ---
 
+## Start building with Hugging Face products
+
+Hugging Face provides the model hub, deployment infrastructure, and open-source libraries that make up the standard developer workflow for modern AI applications. Whether you are loading a pretrained model, publishing a demo, or managing training data, Hugging Face has a product for each stage of the process. Explore what the community has built at [Hugging Face Use Cases and Applications](/apps/tech/huggingface).
+
+---
+
 ## Core Products
 
 ### The Hub
 
 The Hugging Face Hub is a collaborative repository for models, datasets, and applications. Developers can host, version, and share any model type, including LLMs, diffusion models, embeddings, and classifiers. The Hub supports private and public repos, fine-tuned model versions, and model cards that document intended use and limitations.
+
+For API reference, SDK documentation, and getting started resources, see our [Hugging Face Hub tech page](/tech/huggingface/huggingface-hub).
 
 ### Transformers
 
@@ -32,6 +40,8 @@ The Transformers library is the most widely used open-source library for working
 ### Spaces
 
 Spaces lets developers build and host interactive ML applications directly on Hugging Face infrastructure. Most Spaces are built with Gradio or Streamlit and connect to models from the Hub. Spaces can be deployed on free shared CPU instances or upgraded to GPU-backed hardware for faster inference.
+
+For deployment guides, GPU tiers, and examples, see our [Hugging Face Spaces tech page](/tech/huggingface/huggingface-spaces).
 
 ### Inference API and Endpoints
 


### PR DESCRIPTION
## Summary

- Updates `technologies/huggingface/index.mdx`
- Adds "Start building with Hugging Face products" intro section
- Adds links to `huggingface-hub` and `huggingface-spaces` sub-pages within their respective product descriptions

## Test plan

- [ ] Internal links to sub-pages resolve correctly
- [ ] Page renders without breaking existing content