### PR TITLE
feat: add individual Qwen model pages

### DIFF
--- a/technologies/qwen/index.mdx
+++ b/technologies/qwen/index.mdx
@@ -1,0 +1,88 @@
+---
+title: "Qwen"
+description: "Qwen is a family of open-source and proprietary large language models developed by Alibaba Cloud, covering text, vision, and code, accessible via an OpenAI-compatible API."
+authorUsername: "stevekimoi"
+---
+
+# Qwen
+
+Qwen is a large language model family developed by the Qwen team at Alibaba Cloud. First released in 2023, the series spans dense and mixture-of-experts architectures across text, vision, and code, with most models published under the Apache 2.0 license. Developers can access Qwen models through Alibaba Cloud's Model Studio (DashScope) using an OpenAI-compatible API, or download weights directly from Hugging Face and GitHub.
+
+| General | |
+|---------|--|
+| **Company** | [Qwen / Alibaba Cloud](https://qwen.ai) |
+| **Founded** | 2023 (first model release) |
+| **Headquarters** | Hangzhou, China |
+| **Website** | [qwen.ai](https://qwen.ai) |
+| **Documentation** | [Qwen Docs](https://qwenlm.github.io) |
+| **GitHub** | [github.com/QwenLM](https://github.com/QwenLM) |
+| **Hugging Face** | [huggingface.co/Qwen](https://huggingface.co/Qwen) |
+| **Type** | LLM Provider / Open-Source AI Lab |
+
+---
+
+## Core Products
+
+### Qwen3 (Text LLMs)
+Qwen3 is the flagship text model family, released in April 2025 under Apache 2.0. It includes dense models from 0.6B to 32B parameters and mixture-of-experts models up to 235B total parameters (22B active). All models support multilingual text generation, reasoning, tool use, and agentic workflows.
+
+### Qwen3-Coder
+Qwen3-Coder is a coding-specialized model with 480B total parameters and 35B active, trained on 7.5 trillion tokens with a 70% code-focused dataset. Released in July 2025, it achieves state-of-the-art results among open models on SWE-Bench Verified.
+
+### Qwen3.6 (Vision-Language)
+Qwen3.6 is a multimodal model with a unified vision-language architecture trained on trillions of multimodal tokens. It supports text and image inputs across 201 languages and dialects, with capabilities covering reasoning, coding, and visual understanding.
+
+### Qwen-Image-2.0
+Qwen-Image-2.0 is a 7B-parameter image generation model supporting photorealism, professional typography, and unified generation-editing workflows, released in February 2026.
+
+### Qwen-MT
+Qwen-MT is a translation model covering 92 major languages and dialects, reaching over 95% of the global population. It is designed for high-quality translation in production pipelines.
+
+### Qwen Code
+Qwen Code is an open-source terminal coding agent optimized for the Qwen model series. It supports writing features, fixing bugs, navigating large codebases, and generating pull requests, with GitHub Actions integration available.
+
+---
+
+## Developer Resources
+
+Qwen models are accessible through Alibaba Cloud Model Studio (DashScope) via an OpenAI-compatible API, or as open weights on Hugging Face. The API supports both text-only and multimodal models.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Qwen Documentation](https://qwenlm.github.io) (model cards, quickstarts, and research notes)
+- [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/) (API reference and DashScope SDK docs)
+- [GitHub (QwenLM)](https://github.com/QwenLM) (open-source model weights, code, and tools)
+- [Hugging Face (Qwen)](https://huggingface.co/Qwen) (download model weights and datasets)
+- [Qwen API Platform](https://qwen.ai/apiplatform) (get an API key and start building)
+- [Qwen Studio](https://qwen.ai) (web interface for chat, image understanding, and generation)
+
+---
+
+## Key Features
+
+**Open weights under Apache 2.0**
+Most Qwen3 models are released under Apache 2.0, allowing commercial use, fine-tuning, and redistribution without restrictions.
+
+**OpenAI-compatible API**
+Qwen models are served through DashScope using the OpenAI-compatible endpoint format, making it straightforward to use Qwen models in existing OpenAI SDK integrations.
+
+**Multilingual coverage**
+Qwen3.6 supports 201 languages and dialects. Qwen-MT covers 92 major languages for dedicated translation tasks.
+
+**Mixture-of-Experts (MoE) architecture**
+The largest Qwen3 models use MoE, activating only a subset of total parameters per token (for example, 22B of 235B active). This reduces inference cost relative to comparably capable dense models.
+
+---
+
+## Use Cases
+
+**Agentic coding workflows**
+Qwen3-Coder and Qwen Code are designed for software development tasks: writing features, fixing bugs, navigating large codebases, and generating pull requests via the terminal or CI pipelines.
+
+**Multilingual applications**
+Qwen-MT and Qwen3.6's broad language support make them suitable for translation tools, multilingual chatbots, and localized content pipelines.
+
+**Multimodal document and image processing**
+Qwen3.6 handles image understanding, document analysis, and visual reasoning alongside text, enabling applications like document Q&A and visual search.

--- a/technologies/qwen/qwen-code.mdx
+++ b/technologies/qwen/qwen-code.mdx
@@ -1,0 +1,59 @@
+---
+title: "Qwen Code"
+author: "qwen"
+description: "Qwen Code is an open-source terminal AI coding agent from Alibaba Cloud, optimized for Qwen3-Coder, that understands large codebases and supports GitHub Actions integration for automated workflows."
+---
+
+# Qwen Code
+
+[Qwen Code](https://qwen.ai/qwencode) is an open-source AI agent for the terminal, released alongside Qwen3-Coder in July 2025. It is a fork of Google's Gemini CLI adapted with customized prompts and function-calling protocols for the Qwen3-Coder model. It is designed for tasks that span large codebases: understanding existing code, writing and editing files, running shell commands, and handling multi-step agentic workflows directly from the command line.
+
+| General | |
+|---------|--|
+| **Release date** | Jul 2025 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Open-source terminal coding agent |
+| **License** | Apache 2.0 |
+| **GitHub** | [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) |
+| **Documentation** | [qwenlm.github.io/qwen-code-docs](https://qwenlm.github.io/qwen-code-docs/en/) |
+
+---
+
+## Core Features
+
+- **Large codebase navigation**: reads and reasons across files beyond the normal context window using a structured retrieval approach.
+- **File editing and shell execution**: writes, patches, and runs code directly in the terminal without leaving the CLI.
+- **PR and rebase automation**: automates repetitive git tasks including pull request creation, rebases, and commit formatting.
+- **GitHub Actions integration**: the `qwen-code-action` GitHub Action brings Qwen Code into CI/CD workflows for automated issue triage, code review, and pull request handling.
+- **Optimized for Qwen3-Coder**: ships with customized system prompts and function-calling configs tuned for Qwen3-Coder's 256K context and agentic RL training.
+
+---
+
+## GitHub Actions Workflows
+
+The `qwen-code-action` provides pre-built workflow templates:
+
+- **Issue triage**: automatically categorize and label issues on creation or on a schedule.
+- **PR review**: run code analysis and leave review comments on new pull requests.
+- **On-demand collaboration**: mention Qwen Code in an issue or PR comment to trigger a task conversationally.
+
+---
+
+## Tools and Resources
+
+- **[GitHub (QwenLM/qwen-code)](https://github.com/QwenLM/qwen-code)**: source code, installation instructions, and release notes.
+- **[Qwen Code Docs](https://qwenlm.github.io/qwen-code-docs/en/)**: configuration, authentication, and GitHub Actions setup.
+- **[Qwen Code product page](https://qwen.ai/qwencode)**: overview and quickstart on qwen.ai.
+- **[GitHub Actions guide](https://qwenlm.github.io/qwen-code-docs/en/users/integration-github-action/)**: step-by-step setup for CI/CD integration.
+
+---
+
+## Ecosystem and Integrations
+
+- Uses the [Qwen API Platform](https://qwen.ai/apiplatform) for model access (supports the OpenAI-compatible DashScope endpoint).
+- Works with any model accessible via an OpenAI-compatible API, not just Qwen3-Coder.
+- GitHub Actions integration works with any GitHub repository without additional infrastructure.
+
+---
+
+Install Qwen Code from [GitHub](https://github.com/QwenLM/qwen-code) and configure an API key from the [Qwen API Platform](https://qwen.ai/apiplatform) to get started.

--- a/technologies/qwen/qwen-image-2.mdx
+++ b/technologies/qwen/qwen-image-2.mdx
@@ -1,0 +1,58 @@
+---
+title: "Qwen-Image-2.0"
+author: "qwen"
+description: "Qwen-Image-2.0 is a 7B-parameter image generation and editing model from Alibaba Cloud with native 2K resolution support, released in February 2026, ranked first on AI Arena in both text-to-image and image editing."
+---
+
+# Qwen-Image-2.0
+
+[Qwen-Image-2.0](https://github.com/QwenLM/Qwen-Image) is Alibaba Cloud's second-generation image foundation model, released on February 10, 2026. It combines image generation and editing into a single model, replacing the separate pipelines required by earlier approaches. The architecture pairs an 8B Qwen3-VL encoder with a 7B diffusion decoder, producing a leaner design than its predecessor (which used 20B parameters) while achieving higher benchmark scores. It supports native 2048x2048 resolution output.
+
+| General | |
+|---------|--|
+| **Release date** | 10 Feb 2026 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Image generation and editing model |
+| **Architecture** | 8B Qwen3-VL encoder + 7B diffusion decoder |
+| **GitHub** | [QwenLM/Qwen-Image](https://github.com/QwenLM/Qwen-Image) |
+| **Documentation** | [qwenlm.github.io](https://qwenlm.github.io) |
+
+---
+
+## Core Features
+
+- **Unified generation and editing**: a single model handles both text-to-image generation and instruction-based image editing without switching pipelines.
+- **Native 2K resolution**: generates images at up to 2048x2048 pixels natively.
+- **Professional typography**: supports up to 1,000-token prompt instructions for text-heavy visuals, generating accurate text in posters, infographics, slides, and comics.
+- **Photorealism**: produces fine-grained detail at 2K including skin texture, fabric weave, and natural foliage.
+- **Efficient architecture**: 7B active parameters vs. 20B in Qwen-Image 1.0, with faster inference and higher quality.
+
+---
+
+## Benchmarks
+
+| Benchmark | Qwen-Image-2.0 | FLUX.1 (12B) |
+|-----------|---------------|--------------|
+| DPG-Bench | 88.32 | 83.84 |
+| AI Arena (text-to-image) | #1 | |
+| AI Arena (image editing) | #1 | |
+
+---
+
+## Tools and Resources
+
+- **[GitHub (QwenLM/Qwen-Image)](https://github.com/QwenLM/Qwen-Image)**: model code and usage examples.
+- **[Qwen API Platform](https://qwen.ai/apiplatform)**: API access for generation and editing endpoints.
+- **[Qwen Studio](https://qwen.ai)**: web interface to try image generation and editing without setup.
+
+---
+
+## Ecosystem and Integrations
+
+- Accessible via Alibaba Cloud DashScope API for programmatic generation and editing.
+- Available through Qwen Studio for no-code testing.
+- The encoder backbone (Qwen3-VL) is the same model used for vision-language understanding tasks.
+
+---
+
+To get started, visit [Qwen Studio](https://qwen.ai) for a live demo, or use the [Qwen API Platform](https://qwen.ai/apiplatform) for API access with the DashScope SDK.

--- a/technologies/qwen/qwen3-coder.mdx
+++ b/technologies/qwen/qwen3-coder.mdx
@@ -1,0 +1,61 @@
+---
+title: "Qwen3-Coder"
+author: "qwen"
+description: "Qwen3-Coder is an open-weight mixture-of-experts coding model from Alibaba Cloud with 480B total and 35B active parameters, trained on 7.5 trillion tokens with 70% code content, supporting 256K native context."
+---
+
+# Qwen3-Coder
+
+[Qwen3-Coder](https://qwenlm.github.io/blog/qwen3-coder/) is Alibaba Cloud's dedicated coding model, released on July 22, 2025. The flagship variant, Qwen3-Coder-480B-A35B-Instruct, is a mixture-of-experts model trained on 7.5 trillion tokens across 358 programming languages, with 70% of the training data being code. It supports 256K tokens of native context, extensible to 1M tokens with extrapolation, making it suited to repository-scale tasks and multi-file agentic workflows.
+
+| General | |
+|---------|--|
+| **Release date** | 22 Jul 2025 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Open-weight coding LLM (MoE) |
+| **License** | Apache 2.0 |
+| **GitHub** | [QwenLM/Qwen3-Coder](https://github.com/QwenLM/Qwen3-Coder) |
+| **Hugging Face** | [Qwen3-Coder-480B-A35B-Instruct](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct) |
+| **Documentation** | [qwenlm.github.io/blog/qwen3-coder](https://qwenlm.github.io/blog/qwen3-coder/) |
+
+---
+
+## Core Features
+
+- **480B/35B MoE architecture**: 480B total parameters with 35B active per token, using 160 experts with 8 activated per inference step.
+- **256K native context**: natively processes 256,000 tokens, with extrapolation support up to 1,000,000 tokens.
+- **358 programming languages**: trained on a broad code corpus covering mainstream and niche languages.
+- **Agent RL post-training**: long-horizon reinforcement learning trains the model to solve real-world tasks through multi-turn tool interactions.
+- **Apache 2.0**: weights are available for commercial use and fine-tuning.
+
+---
+
+## Benchmarks
+
+| Benchmark | Score |
+|-----------|-------|
+| SWE-Bench Verified | 69.6% |
+
+SWE-Bench Verified scores are state-of-the-art among open models at release, comparable to Claude Sonnet 4.
+
+---
+
+## Tools and Resources
+
+- **[Qwen3-Coder Blog Post](https://qwenlm.github.io/blog/qwen3-coder/)**: release announcement with benchmark details.
+- **[GitHub (QwenLM/Qwen3-Coder)](https://github.com/QwenLM/Qwen3-Coder)**: model code and usage examples.
+- **[Hugging Face](https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct)**: model weights.
+- **[Qwen Code](https://github.com/QwenLM/qwen-code)**: open-source terminal agent built on Qwen3-Coder.
+- **[Together AI](https://www.together.ai/models/qwen3-coder-480b-a35b-instruct)**: hosted API access.
+
+---
+
+## Ecosystem and Integrations
+
+- Paired with [Qwen Code](https://qwen.ai/qwencode), an open-source terminal coding agent with GitHub Actions support.
+- Accessible via the Alibaba Cloud DashScope API using an OpenAI-compatible endpoint.
+- Available on Together AI, LM Studio, and Ollama for local and cloud inference.
+
+---
+
+To use Qwen3-Coder via API, get an API key on the [Qwen API Platform](https://qwen.ai/apiplatform). For local agentic coding, see the [Qwen Code terminal agent](https://github.com/QwenLM/qwen-code).

--- a/technologies/qwen/qwen3-mt.mdx
+++ b/technologies/qwen/qwen3-mt.mdx
@@ -1,0 +1,55 @@
+---
+title: "Qwen3-MT"
+author: "qwen"
+description: "Qwen3-MT is a machine translation model from Alibaba Cloud supporting 92 languages, fine-tuned from Qwen3 with a lightweight MoE backbone, priced at $0.5 per million tokens."
+---
+
+# Qwen3-MT
+
+[Qwen3-MT](https://qwenlm.github.io/blog/qwen-mt/) is a machine translation model developed by Alibaba Cloud's Qwen team, released on July 25, 2025. It is fine-tuned from Qwen3 with a lightweight Mixture-of-Experts backbone and trained on trillions of multilingual tokens spanning formal, technical, and conversational text. The model covers 92 major languages and prominent dialects, reaching over 95% of the global population.
+
+| General | |
+|---------|--|
+| **Release date** | 25 Jul 2025 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Machine translation model (MoE fine-tune) |
+| **License** | Commercial API |
+| **Documentation** | [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/machine-translation) |
+| **API** | DashScope via [Qwen API Platform](https://qwen.ai/apiplatform) |
+
+---
+
+## Core Features
+
+- **92 languages**: covers major world languages and prominent dialects, reaching 95% of the global population.
+- **Terminology control**: allows custom terminology dictionaries to keep brand names, technical terms, and product names consistent.
+- **Domain prompting**: a domain hint lets the model adapt output style for legal, medical, technical, or conversational text.
+- **Translation memory**: integrates past translation pairs so repeated segments stay consistent across large documents.
+- **Competitive pricing**: priced at $0.5 per million tokens, significantly lower than dense large models for translation workloads.
+
+---
+
+## Performance
+
+Qwen3-MT outperforms comparably-sized models on translation benchmarks, including GPT-4.1-mini and Gemini-2.5-Flash, while remaining competitive with larger models like GPT-4.1 and Gemini-2.5-Pro on translation quality metrics.
+
+---
+
+## Tools and Resources
+
+- **[Qwen-MT Blog Post](https://qwenlm.github.io/blog/qwen-mt/)**: technical overview and benchmark results.
+- **[Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/machine-translation)**: full API documentation and integration guide.
+- **[Qwen API Platform](https://qwen.ai/apiplatform)**: generate an API key to get started.
+- **[DashScope SDK (PyPI)](https://pypi.org/project/dashscope/)**: Python SDK for calling Qwen3-MT and other Qwen models.
+
+---
+
+## Ecosystem and Integrations
+
+- Served through Alibaba Cloud DashScope, accessible with the OpenAI-compatible endpoint or the native DashScope SDK.
+- Supports batch translation for high-volume document workflows.
+- Term dictionaries and translation memory integrate via API request parameters, requiring no custom fine-tuning.
+
+---
+
+Get started by generating an API key on the [Qwen API Platform](https://qwen.ai/apiplatform) and following the [Model Studio translation guide](https://www.alibabacloud.com/help/en/model-studio/machine-translation).

--- a/technologies/qwen/qwen3-vl.mdx
+++ b/technologies/qwen/qwen3-vl.mdx
@@ -1,0 +1,62 @@
+---
+title: "Qwen3-VL"
+author: "qwen"
+description: "Qwen3-VL is an open-weight vision-language model series from Alibaba Cloud that processes images, videos, and text, available in 2B and 8B sizes under Apache 2.0."
+---
+
+# Qwen3-VL
+
+[Qwen3-VL](https://github.com/QwenLM/Qwen3-VL) is Alibaba Cloud's vision-language model series, designed to understand and reason over images, videos, and text in a single architecture. It is available in 2B and 8B parameter sizes, both released under Apache 2.0. The architecture handles diverse visual tasks including document understanding, chart analysis, image-based question answering, and video comprehension.
+
+| General | |
+|---------|--|
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Open-weight vision-language LLM |
+| **License** | Apache 2.0 |
+| **GitHub** | [QwenLM/Qwen3-VL](https://github.com/QwenLM/Qwen3-VL) |
+| **Hugging Face** | [Qwen3-VL-8B-Instruct](https://huggingface.co/Qwen/Qwen3-VL-8B-Instruct) |
+| **Technical Report** | [arxiv.org/abs/2511.21631](https://arxiv.org/abs/2511.21631) |
+| **Documentation** | [qwenlm.github.io](https://qwenlm.github.io) |
+
+---
+
+## Core Features
+
+- **Multimodal inputs**: accepts text, images, and videos in a single conversation turn.
+- **Document and chart understanding**: parses structured visual content like tables, slides, PDFs, and infographics.
+- **Video comprehension**: understands multi-frame video sequences and answers temporal questions.
+- **Thinking mode**: includes a reasoning variant (Qwen3-VL-8B-Thinking) for step-by-step visual problem solving.
+- **Apache 2.0**: weights are open for commercial use and fine-tuning.
+
+---
+
+## Model Variants
+
+| Variant | Parameters | Key capability |
+|---------|-----------|----------------|
+| Qwen3-VL-2B-Instruct | 2B | Lightweight multimodal inference |
+| Qwen3-VL-8B-Instruct | 8B | General vision-language tasks |
+| Qwen3-VL-8B-Thinking | 8B | Step-by-step visual reasoning |
+
+---
+
+## Tools and Resources
+
+- **[GitHub (QwenLM/Qwen3-VL)](https://github.com/QwenLM/Qwen3-VL)**: model code, usage examples, and fine-tuning scripts.
+- **[Hugging Face (Qwen)](https://huggingface.co/Qwen)**: download weights for all variants.
+- **[Technical Report](https://arxiv.org/abs/2511.21631)**: arXiv paper with architecture and benchmark details.
+- **[Qwen API Platform](https://qwen.ai/apiplatform)**: access Qwen3-VL via the DashScope API.
+- **[Ollama](https://ollama.com/library/qwen3-vl)**: run Qwen3-VL locally.
+
+---
+
+## Ecosystem and Integrations
+
+- Served through Alibaba Cloud DashScope via an OpenAI-compatible vision endpoint.
+- Available on Ollama for local multimodal inference.
+- Weights downloadable from Hugging Face Hub in standard and GGUF formats.
+- Forms the encoder backbone for Qwen-Image-2.0, the image generation model.
+
+---
+
+Model weights are available on [Hugging Face](https://huggingface.co/Qwen). API access is available through the [Qwen API Platform](https://qwen.ai/apiplatform) and [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/).

--- a/technologies/qwen/qwen3.mdx
+++ b/technologies/qwen/qwen3.mdx
@@ -1,0 +1,78 @@
+---
+title: "Qwen3"
+author: "qwen"
+description: "Qwen3 is a family of open-weight large language models from Alibaba Cloud, spanning dense and mixture-of-experts architectures from 0.6B to 235B parameters, released in April 2025 under Apache 2.0."
+---
+
+# Qwen3
+
+[Qwen3](https://qwenlm.github.io/blog/qwen3/) is the third-generation text model family from Alibaba Cloud's Qwen team, released on April 28, 2025. It covers six dense sizes (0.6B to 32B) and two MoE variants, all trained on approximately 36 trillion tokens across 119 languages. A key design choice is a unified thinking and non-thinking mode in every model, so developers can choose between step-by-step reasoning and fast single-pass responses without switching models.
+
+| General | |
+|---------|--|
+| **Release date** | 28 Apr 2025 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Open-weight text LLM family |
+| **License** | Apache 2.0 |
+| **GitHub** | [QwenLM/Qwen3](https://github.com/QwenLM/Qwen3) |
+| **Hugging Face** | [huggingface.co/Qwen](https://huggingface.co/Qwen) |
+| **Documentation** | [qwenlm.github.io/blog/qwen3](https://qwenlm.github.io/blog/qwen3/) |
+
+---
+
+## Core Features
+
+- **Thinking/non-thinking mode**: every model supports both step-by-step chain-of-thought reasoning and direct response generation within a single checkpoint.
+- **Thinking budget**: developers can set a token budget for the reasoning phase, allowing inference cost to be tuned per request.
+- **Long context**: models at 4B and above support 131,072-token context windows; 0.6B and 1.7B support 32,768 tokens.
+- **Multilingual**: pretrained on 119 languages and dialects.
+- **Apache 2.0**: all weights are released for commercial use, fine-tuning, and redistribution.
+
+---
+
+## Model Variants
+
+| Variant | Total Params | Active Params | Context | Best for |
+|---------|-------------|---------------|---------|----------|
+| Qwen3-0.6B | 0.6B | 0.6B | 32K | Edge and on-device |
+| Qwen3-1.7B | 1.7B | 1.7B | 32K | Lightweight inference |
+| Qwen3-4B | 4B | 4B | 128K | Balanced performance |
+| Qwen3-8B | 8B | 8B | 128K | General tasks |
+| Qwen3-14B | 14B | 14B | 128K | Higher accuracy |
+| Qwen3-32B | 32B | 32B | 128K | Strong reasoning |
+| Qwen3-30B-A3B | 30B | 3B | 128K | Efficient MoE |
+| Qwen3-235B-A22B | 235B | 22B | 128K | Flagship MoE |
+
+---
+
+## Benchmarks
+
+The flagship Qwen3-235B-A22B model scores:
+
+- **AIME '24:** 85.7
+- **AIME '25:** 81.5
+- **LiveCodeBench v5:** 70.7
+- **BFCL v3:** 70.8
+
+---
+
+## Tools and Resources
+
+- **[Qwen3 Blog Post](https://qwenlm.github.io/blog/qwen3/)**: official release notes and technical details.
+- **[Hugging Face (Qwen)](https://huggingface.co/Qwen)**: download model weights and GGUF files.
+- **[Technical Report](https://arxiv.org/abs/2505.09388)**: arXiv paper covering architecture, training, and evaluation.
+- **[Ollama](https://ollama.com/library/qwen3)**: run Qwen3 models locally.
+- **[Qwen API Platform](https://qwen.ai/apiplatform)**: access models via OpenAI-compatible API.
+
+---
+
+## Ecosystem and Integrations
+
+- Available on Hugging Face Hub in both standard and GGUF formats.
+- Accessible via Alibaba Cloud DashScope using an OpenAI-compatible endpoint.
+- Supported by Ollama, LM Studio, and major inference frameworks including vLLM and llama.cpp.
+- All sizes available for fine-tuning using standard supervised fine-tuning and RL pipelines.
+
+---
+
+Qwen3 weights are available immediately on [Hugging Face](https://huggingface.co/Qwen). To access via API, generate a key on the [Qwen API Platform](https://qwen.ai/apiplatform) and follow the [Model Studio documentation](https://www.alibabacloud.com/help/en/model-studio/).


### PR DESCRIPTION
## Summary

- Adds 6 individual technology pages under `technologies/qwen/`
- **Qwen3** (`qwen3.mdx`): text LLM family, dense + MoE variants from 0.6B to 235B, released Apr 2025
- **Qwen3-Coder** (`qwen3-coder.mdx`): 480B/35B MoE coding model, 256K context, 69.6% SWE-Bench, released Jul 2025
- **Qwen3-VL** (`qwen3-vl.mdx`): vision-language model in 2B and 8B sizes, image/video/text input
- **Qwen-Image-2.0** (`qwen-image-2.mdx`): image generation and editing model, native 2K resolution, #1 on AI Arena, released Feb 2026
- **Qwen3-MT** (`qwen3-mt.mdx`): translation model, 92 languages, $0.5/million tokens, released Jul 2025
- **Qwen Code** (`qwen-code.mdx`): open-source terminal coding agent with GitHub Actions integration

## Test plan

- [ ] All 6 files have `title`, `description`, and `author` frontmatter fields
- [ ] No em dashes in any body content
- [ ] No invented facts (all parameter counts, dates, and benchmarks sourced from official blogs and HuggingFace)
- [ ] All external URLs verified (qwenlm.github.io, github.com/QwenLM, huggingface.co/Qwen)
- [ ] Depends on PR #976 (Qwen provider index page) being merged first