### PR TITLE
feat: add Qwen3-MT technology page

### DIFF
--- a/technologies/qwen/qwen3-mt.mdx
+++ b/technologies/qwen/qwen3-mt.mdx
@@ -1,0 +1,55 @@
+---
+title: "Qwen3-MT"
+author: "qwen"
+description: "Qwen3-MT is a machine translation model from Alibaba Cloud supporting 92 languages, fine-tuned from Qwen3 with a lightweight MoE backbone, priced at $0.5 per million tokens."
+---
+
+# Qwen3-MT
+
+[Qwen3-MT](https://qwenlm.github.io/blog/qwen-mt/) is a machine translation model developed by Alibaba Cloud's Qwen team, released on July 25, 2025. It is fine-tuned from Qwen3 with a lightweight Mixture-of-Experts backbone and trained on trillions of multilingual tokens spanning formal, technical, and conversational text. The model covers 92 major languages and prominent dialects, reaching over 95% of the global population.
+
+| General | |
+|---------|--|
+| **Release date** | 25 Jul 2025 |
+| **Developer** | Qwen / Alibaba Cloud |
+| **Type** | Machine translation model (MoE fine-tune) |
+| **License** | Commercial API |
+| **Documentation** | [Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/machine-translation) |
+| **API** | DashScope via [Qwen API Platform](https://qwen.ai/apiplatform) |
+
+---
+
+## Core Features
+
+- **92 languages**: covers major world languages and prominent dialects, reaching 95% of the global population.
+- **Terminology control**: allows custom terminology dictionaries to keep brand names, technical terms, and product names consistent.
+- **Domain prompting**: a domain hint lets the model adapt output style for legal, medical, technical, or conversational text.
+- **Translation memory**: integrates past translation pairs so repeated segments stay consistent across large documents.
+- **Competitive pricing**: priced at $0.5 per million tokens, significantly lower than dense large models for translation workloads.
+
+---
+
+## Performance
+
+Qwen3-MT outperforms comparably-sized models on translation benchmarks, including GPT-4.1-mini and Gemini-2.5-Flash, while remaining competitive with larger models like GPT-4.1 and Gemini-2.5-Pro on translation quality metrics.
+
+---
+
+## Tools and Resources
+
+- **[Qwen-MT Blog Post](https://qwenlm.github.io/blog/qwen-mt/)**: technical overview and benchmark results.
+- **[Alibaba Cloud Model Studio](https://www.alibabacloud.com/help/en/model-studio/machine-translation)**: full API documentation and integration guide.
+- **[Qwen API Platform](https://qwen.ai/apiplatform)**: generate an API key to get started.
+- **[DashScope SDK (PyPI)](https://pypi.org/project/dashscope/)**: Python SDK for calling Qwen3-MT and other Qwen models.
+
+---
+
+## Ecosystem and Integrations
+
+- Served through Alibaba Cloud DashScope, accessible with the OpenAI-compatible endpoint or the native DashScope SDK.
+- Supports batch translation for high-volume document workflows.
+- Term dictionaries and translation memory integrate via API request parameters, requiring no custom fine-tuning.
+
+---
+
+Get started by generating an API key on the [Qwen API Platform](https://qwen.ai/apiplatform) and following the [Model Studio translation guide](https://www.alibabacloud.com/help/en/model-studio/machine-translation).

--- a/technologies/qwen/qwen3-mt.mdx
+++ b/technologies/qwen/qwen3-mt.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Qwen3-MT"
-author: "qwen"
+author: "stevekimoi"
 description: "Qwen3-MT is a machine translation model from Alibaba Cloud supporting 92 languages, fine-tuned from Qwen3 with a lightweight MoE backbone, priced at $0.5 per million tokens."
 ---
 


### PR DESCRIPTION
## Summary

Adds \`technologies/qwen/qwen3-mt.mdx\` for the Qwen3-MT translation model.

- Released July 25, 2025, fine-tuned from Qwen3 with a lightweight MoE backbone
- Supports 92 languages and dialects, covering 95%+ of the global population
- Features: terminology control, domain prompting, translation memory
- Priced at \$0.5 per million tokens via DashScope API

## Test plan

- [ ] Frontmatter has \`title\`, \`description\`, and \`author\`
- [ ] No em dashes in body content
- [ ] Facts sourced from qwenlm.github.io/blog/qwen-mt and alibabacloud.com docs