### PR TITLE
chore: update image standard from Cloudinary to Cloudflare Images

### DIFF
--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -23,7 +23,7 @@ Read the full draft file.
 
 - [ ] **No placeholders** — no TODOs, no `[insert X here]`, no `...` in code blocks
 - [ ] **No skeleton sections** — every H2/H3 has real prose, not just a heading
-- [ ] **Images use Cloudinary** — all image URLs are `https://res.cloudinary.com/dygkv9gam/image/upload/...` — no local paths, no hotlinked external images
+- [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: POST to `https://api.cloudflare.com/client/v4/accounts/df2eef4c5a85afb0880466202079da1b/images/v1` with `Authorization: Bearer {CLOUDFLARE_IMAGES_TOKEN}` and the image as multipart `file`.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
 

--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -23,7 +23,7 @@ Read the full draft file.
 
 - [ ] **No placeholders** — no TODOs, no `[insert X here]`, no `...` in code blocks
 - [ ] **No skeleton sections** — every H2/H3 has real prose, not just a heading
-- [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: POST to `https://api.cloudflare.com/client/v4/accounts/df2eef4c5a85afb0880466202079da1b/images/v1` with `Authorization: Bearer {CLOUDFLARE_IMAGES_TOKEN}` and the image as multipart `file`.
+- [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: use the Cloudflare Images API with the `CLOUDFLARE_IMAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from `.agents/skills/.env`.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,8 +16,8 @@ topics/           — Topic index pages
 ## Content standards
 
 - **Frontmatter required on every file:** `title`, `description`, `image`, `authorUsername`
-- **Images must use Cloudinary:** all image URLs must be `https://res.cloudinary.com/dygkv9gam/image/upload/...` — no local paths, no hotlinked external images
-- **Cloudinary cloud name:** `dygkv9gam` (credentials in env as `CLOUDINARY_URL`)
+- **Images must use Cloudflare Images:** all image URLs must be `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no hotlinked external images, no Cloudinary URLs
+- **Cloudflare Images account hash:** `K11gkZF3xaVyYzFESMdWIQ` (API token in `.agents/skills/.env` as `CLOUDFLARE_IMAGES_TOKEN`, account ID `df2eef4c5a85afb0880466202079da1b`)
 - **Author username:** `stevekimoi`
 - **SEO guidelines:** see `SEO_GUIDELINES.md` for keyword strategy and frontmatter formatting rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ topics/           — Topic index pages
 
 - **Frontmatter required on every file:** `title`, `description`, `image`, `authorUsername`
 - **Images must use Cloudflare Images:** all image URLs must be `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no hotlinked external images, no Cloudinary URLs
-- **Cloudflare Images account hash:** `K11gkZF3xaVyYzFESMdWIQ` (API token in `.agents/skills/.env` as `CLOUDFLARE_IMAGES_TOKEN`, account ID `df2eef4c5a85afb0880466202079da1b`)
+- **Cloudflare Images account hash:** `K11gkZF3xaVyYzFESMdWIQ` (API token in `.agents/skills/.env` as `CLOUDFLARE_IMAGES_TOKEN`)
 - **Author username:** `stevekimoi`
 - **SEO guidelines:** see `SEO_GUIDELINES.md` for keyword strategy and frontmatter formatting rules
 


### PR DESCRIPTION
## Summary

Updates the two places that defined Cloudinary as the image standard, following the completed migration to Cloudflare Images (PR #984).

- **`CLAUDE.md`**: replaces Cloudinary image URL requirement with Cloudflare Images URL format and credentials
- **`.agents/skills/publish-check/SKILL.md`**: updates the image check from Cloudinary to Cloudflare Images, including the upload API endpoint for new images

## Test plan

- [x] `CLAUDE.md` no longer references Cloudinary
- [x] `publish-check` skill correctly rejects Cloudinary URLs and accepts `imagedelivery.net` URLs
- [x] Upload instructions in `publish-check` are accurate