### PR TITLE
feat: replace demo video with workshop YouTube embed on AMD HF tutorial

### DIFF
--- a/tutorials/en/amd-huggingface-deployment-for-ai-hackathons.mdx
+++ b/tutorials/en/amd-huggingface-deployment-for-ai-hackathons.mdx
@@ -5,9 +5,9 @@ image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1777559490/LabLab_Bui
 authorUsername: "stevekimoi"
 ---
 
-<video controls width="100%">
-  <source src="https://res.cloudinary.com/dygkv9gam/video/upload/v1777475886/tutorials/amd-hf-space-deployment/demo.mp4" type="video/mp4" />
-</video>
+Watch the full workshop walkthrough before diving in:
+
+<LiteYouTube videoId="_NZn_r2ygCI" containerClassName={"youtubeContainer"} />
 
 ## Introduction
 


### PR DESCRIPTION
## Summary

- Replaces the Cloudinary mp4 embed at the top of the AMD HuggingFace deployment tutorial with the full workshop YouTube video
- Adds a short intro line: "Watch the full workshop walkthrough before diving in"
- Uses the existing `<LiteYouTube>` component pattern (same as `ai-meets-robotics.mdx`)

## Changes

- `tutorials/en/amd-huggingface-deployment-for-ai-hackathons.mdx` — swap `<video>` tag for `<LiteYouTube videoId="_NZn_r2ygCI" />`