### PR TITLE
feat: Hermes Agent vs OpenClaw hackathon comparison

### DIFF
--- a/blog/en/hermes-agent-vs-openclaw-for-ai-hackathon.mdx
+++ b/blog/en/hermes-agent-vs-openclaw-for-ai-hackathon.mdx
@@ -1,0 +1,89 @@
+---
+title: "Hermes Agent vs OpenClaw: Which One Helps You Ship Faster at a Hackathon?"
+description: "Choosing between Hermes Agent and OpenClaw for a hackathon? This breakdown focuses on one thing only: which framework does more work for your project so you can ship before the deadline."
+image: "https://res.cloudinary.com/dygkv9gam/image/upload/v1778242502/blog/rkpues2iefiivaay9ufu.png"
+authorUsername: "stevekimoi"
+---
+
+Most comparisons between **Hermes Agent** and **OpenClaw** ask the wrong question. They want to know which framework has better architecture, more GitHub stars, or a stronger long-term roadmap. At a hackathon, none of that matters.
+
+The only question worth asking is: **which one does more work for your project so you can stay focused on your idea?**
+
+You have 48 to 72 hours. You need a working demo. The framework that eliminates the most manual effort from your actual build is the one you should reach for, not the one with the more impressive feature list.
+
+Here is a clear breakdown of what each framework actually does for you during a hackathon.
+
+## What Hermes Agent Does For Your Build
+
+**Hermes Agent** is an open-source AI agent built by [Nous Research](https://hermes-agent.nousresearch.com/) and [released in February 2026](https://github.com/nousresearch/hermes-agent). The tagline is "the agent that grows with you," and that phrase describes something genuinely useful at a hackathon.
+
+The core mechanism is a **closed learning loop**. After every task Hermes completes, it analyzes its own execution path and writes a reusable skill. You do not have to define workflows manually. You describe what you need, Hermes does it, and then it saves what it learned for next time. In a hackathon context, this means the more you use it, the less you have to repeat yourself. By hour 20, your agent already knows your project's patterns.
+
+The other big advantage is **persistent memory**. Hermes carries context across sessions through `MEMORY.md` and `USER.md` files. If you take a break, switch tasks, or hand off to a teammate, the agent does not start from zero. It knows what was decided, what failed, and what the current goal is.
+
+For coding-heavy hackathon projects, Hermes also ships with built-in **terminal access, file manipulation, browser automation, and code execution in a sandboxed environment**. You can give it a task like "scrape these three APIs, merge the results, and write the data to a JSON file" and walk away. It handles the execution. When it runs into a problem, it writes a fix and tries again.
+
+Setup takes under 30 minutes. One-line installer, connect a model provider (OpenAI, Anthropic, or a local model), and you are running. It supports [20-plus LLM providers](https://hermes-agent.nousresearch.com/docs/integrations/providers) with no lock-in, which matters if your hackathon has a sponsored API.
+
+```bash
+# Install Hermes Agent
+curl -sSL https://hermes-agent.nousresearch.com/install.sh | bash
+hermes
+```
+
+**Hermes is the right choice when your bottleneck is iteration speed.** If your project requires an agent that adapts as you refine the idea, Hermes reduces the number of times you have to manually update behavior.
+
+<Img src="https://res.cloudinary.com/dygkv9gam/image/upload/v1778242502/blog/rkpues2iefiivaay9ufu.png" alt="Hermes Agent vs OpenClaw: Which One Helps You Ship Faster at a Hackathon?" />
+
+## What OpenClaw Does For Your Build
+
+**OpenClaw** is a local-first AI agent platform with [over 345,000 GitHub stars as of April 2026](https://github.com/openclaw/openclaw). Its strength is ecosystem breadth. Where Hermes is a single agent that learns, OpenClaw is a control plane that orchestrates.
+
+The part that matters for hackathon shipping speed is **ClawHub**, OpenClaw's public skill registry with [over 2,800 published skills](https://github.com/openclaw/clawhub). These are community-built connectors for APIs, services, and workflows that you can install with one command. If your project needs to pull data from a web service, send alerts to a Slack channel, schedule a cron job, or chain together multiple agents, there is likely already a skill for it. You are not writing integration code from scratch.
+
+The **multi-channel capability** is also a genuine hackathon superpower. With one setup, your agent can live on Telegram, Slack, Discord, and WhatsApp simultaneously. For a demo, this is visually impressive in a way that matters to judges. Instead of showing a CLI output, you show a live Telegram bot making decisions and taking actions. That kind of demo presentation is hard to replicate quickly in any other framework.
+
+OpenClaw also has first-class **multi-agent orchestration**. If your project involves multiple specialized agents working in parallel, OpenClaw handles routing, session isolation, and coordination natively. You do not have to build that scaffolding yourself.
+
+```bash
+# Install OpenClaw and run the guided setup
+npx openclaw onboard
+```
+
+**OpenClaw is the right choice when your bottleneck is integration depth.** If your project spans multiple platforms, needs pre-built connectors, or relies on a complex coordination layer, OpenClaw's ecosystem means you skip weeks of plumbing work.
+
+## The Security Factor You Cannot Ignore at a Hackathon
+
+This section is not a knock on OpenClaw. It is a practical risk consideration for a high-pressure build environment.
+
+In March 2026, [OpenClaw had nine CVEs filed in four days, including one scoring CVSS 9.9](https://composio.dev/content/openclaw-vs-hermes-agent). Around the same time, [a supply chain audit of ClawHub found 341 malicious skills in an initial scan of 2,857 entries, roughly 12 percent of the registry](https://composio.dev/content/openclaw-vs-hermes-agent). Malicious skills in the open ecosystem represent a real risk if you are installing unfamiliar community packages quickly, which is exactly what happens under hackathon time pressure.
+
+Hermes Agent has zero reported agent-specific CVEs as of April 2026. Because its skills are self-generated rather than downloaded from a public registry, the supply chain attack vector does not apply in the same way.
+
+If you use OpenClaw at a hackathon, stick to the official built-in skills or skills from authors you can verify. Do not bulk-install from ClawHub without reviewing what you are running.
+
+## Which One Should You Choose
+
+The decision comes down to your project type, not your personal preference.
+
+**Choose Hermes Agent if:**
+- Your project is a coding agent, dev tool, or research assistant
+- You need the agent to adapt quickly as your idea evolves during the hackathon
+- You want minimal manual configuration between iterations
+- Your demo is about what the agent figures out, not what it connects to
+
+**Choose OpenClaw if:**
+- Your project needs to span multiple messaging platforms for the demo
+- You need integrations with external APIs or services and do not want to build them from scratch
+- Your use case involves coordinating multiple agents with different roles
+- Your demo benefits from showing a live bot on a familiar consumer platform like Telegram or Slack
+
+There is also a third path that the community has validated: run both. OpenClaw handles the multi-channel coordination and external integrations, while Hermes handles the reasoning and task execution. If you have a team of three or more with someone comfortable setting up infrastructure, this combination is genuinely more capable than either alone.
+
+For a solo developer or a small team under time pressure, pick one. The learning loop that Hermes offers and the skill ecosystem that OpenClaw provides are both real advantages. Choose based on where your project will spend most of its time.
+
+## Build Your Agent Project at a Lablab.ai Hackathon
+
+Both Hermes Agent and OpenClaw have been used in live [AI hackathon](https://lablab.ai/ai-hackathons) projects on [Lablab.ai](https://lablab.ai/). The [SURGE x OpenClaw Hackathon](https://lablab.ai/ai-hackathons/surge-moltbook-hackathon) produced working agent projects across autonomous wallets, capital allocation engines, and GitHub automation tools, all built in under two weeks.
+
+If you want to ship a real agent project, the fastest way to do it is inside a structured hackathon environment with mentors, fellow builders, and a deadline that actually forces you to finish. Browse the current [AI hackathons on Lablab.ai](https://lablab.ai/ai-hackathons), pick a challenge that matches your stack, and build.


### PR DESCRIPTION
## Summary

- Adds a new article comparing Hermes Agent and OpenClaw through a hackathon-specific lens: which framework helps you ship your project faster
- Covers Hermes's self-learning loop and persistent memory vs OpenClaw's ClawHub skill ecosystem and multi-channel demo capabilities
- Includes a security callout on the March 2026 OpenClaw CVE cluster and ClawHub malware findings
- Ends with a decision matrix by project type and CTA to lablab.ai hackathons

## Details

- **File:** `blog/en/hermes-agent-vs-openclaw-for-ai-hackathon.mdx`
- **Word count:** 1,264
- **Cover image:** Cloudinary (`v1778242502/blog/rkpues2iefiivaay9ufu.png`)
- **Notion task:** set to Done

## Test plan

- [ ] Article renders correctly on staging
- [ ] All links resolve (Nous Research, GitHub repos, Composio, lablab.ai hackathons)
- [ ] Cover image loads from Cloudinary