### PR TITLE
feat: Move video embed to top of Featherless Kraken tutorial

### DIFF
--- a/tutorials/en/featherless-kraken-multi-model-financial-agent.mdx
+++ b/tutorials/en/featherless-kraken-multi-model-financial-agent.mdx
@@ -5,6 +5,16 @@ image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/960d9cb8-4bb7-4c42-6ca8
 authorUsername: "stevekimoi"
 ---
 
+<iframe
+  width="100%"
+  height="450"
+  src="https://www.youtube.com/embed/-6Bn6avvejQ"
+  title="Multi-Model Financial Research Agent Demo"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+></iframe>
+
 ## Introduction
 
 Not all financial tasks need the same model. Analyzing 12 hours of OHLC candles and identifying support levels is a different cognitive job from taking that analysis and committing to a BUY, SELL, or HOLD decision with real money on the line. Yet most AI trading tutorials pick a single model and hand it both jobs.
@@ -27,18 +37,6 @@ By the end of this tutorial you will have:
 - A Featherless API client that can swap between [36,000+ models](https://featherless.ai/models) by changing one environment variable
 - Paper trading execution via Kraken CLI
 - A streaming Flask dashboard showing the analysis and decision as they arrive
-
-Here is a full walkthrough of the agent in action:
-
-<iframe
-  width="100%"
-  height="450"
-  src="https://www.youtube.com/embed/-6Bn6avvejQ"
-  title="Multi-Model Financial Research Agent Demo"
-  frameBorder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowFullScreen
-></iframe>
 
 ---
 


### PR DESCRIPTION
Moves the YouTube demo embed to the very top of the tutorial page, before the Introduction heading, so it's the first thing readers see.