### PR TITLE
feat: add Speechmatics technology pages

### DIFF
--- a/technologies/speechmatics/index.mdx
+++ b/technologies/speechmatics/index.mdx
@@ -1,0 +1,70 @@
+---
+title: "Speechmatics"
+description: "Speechmatics is a Cambridge-based speech AI company offering multilingual transcription and real-time voice agent APIs, supporting 55+ languages with industry-leading accuracy."
+---
+
+# Speechmatics
+
+Founded in 2006 by Dr. Tony Robinson, a Cambridge University speech recognition pioneer, Speechmatics builds infrastructure to understand every voice globally. The company's core mission is inclusive, multilingual speech AI, covering transcription, real-time voice agents, and on-device deployment. Speechmatics serves enterprise clients across media, healthcare, financial services, and contact centers.
+
+| General | |
+|---------|--|
+| **Company** | [Speechmatics](https://www.speechmatics.com) |
+| **Founded** | 2006 by Dr. Tony Robinson |
+| **CEO** | Katy Wigdahl |
+| **Headquarters** | Cambridge, United Kingdom |
+| **Website** | [speechmatics.com](https://www.speechmatics.com) |
+| **Documentation** | [docs.speechmatics.com](https://docs.speechmatics.com) |
+| **GitHub** | [github.com/speechmatics](https://github.com/speechmatics) |
+| **Type** | Speech AI / B2B SaaS |
+
+---
+
+## Core Products
+
+### Speechmatics API (Speech-to-Text)
+The Speechmatics API provides batch and real-time transcription across 55+ languages, powered by the Ursa 2 model released in October 2024. It supports speaker diarization, custom dictionaries, automatic translation, and Voice Intelligence add-ons (summarization, sentiment analysis, entity recognition) with no retraining required.
+
+### Speechmatics Flow
+Flow is a voice agent API that combines Speechmatics' speech-to-text with an LLM and text-to-speech into a single real-time pipeline. Developers connect through a single API call to build conversational AI agents with smart turn detection, interruption handling, and function calling support.
+
+---
+
+## Developer Resources
+
+Speechmatics provides SDKs for Python, JavaScript/TypeScript, and .NET, along with a developer portal and free tier to get started without a credit card.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.speechmatics.com) — official API reference, quickstarts, and integration guides
+- [GitHub](https://github.com/speechmatics) — open-source SDKs and client libraries
+- [Developer Portal](https://portal.speechmatics.com) — API key management and usage dashboard
+- [Pricing](https://www.speechmatics.com/pricing) — free tier and pay-as-you-go rates
+
+---
+
+## Key Features
+
+**Multilingual transcription across 55+ languages**
+Speechmatics' Ursa 2 model leads accuracy benchmarks in 62% of supported languages on the FLEURS dataset, with 7.88% WER on Kincaid46 for English, surpassing human-level accuracy on that benchmark.
+
+**Flexible deployment**
+Speechmatics runs on private SaaS cloud, on-premises, on-device, and via Docker or Kubernetes, making it suitable for data-sensitive industries like healthcare and finance.
+
+**Voice Intelligence add-ons**
+Summarization, sentiment analysis, topic detection, chapter generation, and entity recognition layer on top of transcription without requiring additional integration work.
+
+---
+
+## Use Cases
+
+**Contact center automation**
+Real-time transcription and sentiment analysis during calls, combined with Flow for automated voice agent handling of common queries.
+
+**Clinical transcription**
+Speechmatics' Medical Model (launched 2024) targets 93% real-time accuracy and 96% medical keyword recall for English, German, Danish, and Norwegian.
+
+**Media and broadcast**
+Batch transcription of audio and video files for subtitling, archiving, and content search across multiple languages.

--- a/technologies/speechmatics/speechmatics-api.mdx
+++ b/technologies/speechmatics/speechmatics-api.mdx
@@ -1,0 +1,79 @@
+---
+title: "Speechmatics API"
+author: "stevekimoi"
+description: "Speechmatics' speech-to-text API offers batch and real-time transcription across 55+ languages, powered by the Ursa 2 model, with speaker diarization, custom dictionaries, and Voice Intelligence add-ons."
+---
+
+# Speechmatics API
+
+The [Speechmatics API](https://www.speechmatics.com/product/transcription) is the company's core speech-to-text service, providing batch file transcription and real-time streaming transcription via WebSocket. Powered by the Ursa 2 model (released October 2024), it supports 55+ languages and dialects, speaker diarization, automatic translation into 30+ target languages, and a suite of Voice Intelligence add-ons. Transcription requires no model fine-tuning; custom dictionaries of up to 1,000 words take effect immediately.
+
+| General | |
+|---------|--|
+| **Release date** | Generally available; Ursa 2 model released Oct 2024 |
+| **Developer** | Speechmatics |
+| **Type** | Cloud speech-to-text API (batch and real-time) |
+| **License** | Commercial API |
+| **Documentation** | [docs.speechmatics.com/speech-to-text](https://docs.speechmatics.com/speech-to-text) |
+| **GitHub** | [speechmatics/speechmatics-python-sdk](https://github.com/speechmatics/speechmatics-python-sdk) |
+
+---
+
+## Core Features
+
+- **55+ languages and dialects**: broad multilingual support including accent and dialect variants.
+- **Two accuracy tiers**: Enhanced (optimized for accuracy) and Standard (optimized for speed and cost).
+- **Speaker diarization**: multi-speaker detection included at no extra cost in all plans.
+- **Custom dictionary**: up to 1,000 domain-specific words added without retraining.
+- **Automatic translation**: transcripts translated into 30+ target languages via AI.
+- **Voice Intelligence add-ons**: summarization, sentiment analysis, topic detection, chapter generation, and entity recognition.
+- **Audio events detection**: identifies non-speech events in audio.
+- **Smart formatting**: formats numbers, dates, currencies, and capitalization automatically.
+- **Sub-1-second real-time latency**: streaming transcription via WebSocket.
+- **Flexible deployment**: cloud API, on-premises, on-device, Docker, and Kubernetes.
+
+---
+
+## Accuracy Benchmarks (Ursa 2)
+
+| Metric | Result |
+|--------|--------|
+| WER on Kincaid46 (English) | 7.88% (surpasses human-level on that test) |
+| WER improvement vs. previous Ursa | 18% reduction across 50+ languages |
+| FLEURS dataset leadership | Leads in 62% of supported languages |
+| Head-to-head vs. other providers | Wins 88% of comparisons |
+
+---
+
+## Pricing
+
+| Tier | Included | Rate |
+|------|----------|------|
+| Free | 480 minutes/month | No credit card required |
+| Pro | Up to 6,000 hours/month | From $0.24/hour (with discount) |
+| Enterprise | Unlimited scale, no rate limits | Custom |
+
+Volume discounts apply automatically above 500 hours per month per transcription type.
+
+---
+
+## Tools and Resources
+
+- **[Batch API Reference](https://docs.speechmatics.com/jobsapi)**: REST API for asynchronous file transcription jobs.
+- **[Real-time API Reference](https://docs.speechmatics.com/api-ref/realtime-transcription-websocket)**: WebSocket API reference for streaming transcription.
+- **[Python SDK](https://github.com/speechmatics/speechmatics-python-sdk)**: official SDK covering STT batch, real-time, and TTS.
+- **[JavaScript/TypeScript SDK](https://github.com/speechmatics/speechmatics-js-sdk)**: official browser and Node.js SDK.
+- **[Developer Portal](https://portal.speechmatics.com)**: API key management and usage monitoring.
+
+---
+
+## Ecosystem and Integrations
+
+- Integrates with LiveKit, Pipecat, and Vapi for voice pipeline deployments.
+- Available on Microsoft Azure Marketplace.
+- Compatible with on-device and edge deployments via Docker or Kubernetes.
+- Medical Model variant targets clinical transcription in English, German, Danish, and Norwegian.
+
+---
+
+Start building with the [free tier](https://portal.speechmatics.com) (no credit card required) and explore the full API via [docs.speechmatics.com](https://docs.speechmatics.com/speech-to-text).

--- a/technologies/speechmatics/speechmatics-flow.mdx
+++ b/technologies/speechmatics/speechmatics-flow.mdx
@@ -1,0 +1,64 @@
+---
+title: "Speechmatics Flow"
+author: "stevekimoi"
+description: "Speechmatics Flow is a voice agent API that combines speech-to-text, LLM, and TTS into a single real-time pipeline for building conversational AI agents with smart turn detection and interruption handling."
+---
+
+# Speechmatics Flow
+
+[Speechmatics Flow](https://www.speechmatics.com/flow) is a speech-to-speech API for building real-time conversational AI agents. Announced in July 2024, it combines Speechmatics' speech recognition with an LLM and text-to-speech into a single API connection, removing the need to stitch together separate transcription, inference, and synthesis services. Flow handles the real-time challenges of two-way voice conversations, including turn detection, interruption management, and multi-speaker isolation.
+
+| General | |
+|---------|--|
+| **Announced** | July 30, 2024 |
+| **Developer** | Speechmatics |
+| **Type** | Voice agent API (speech-to-speech) |
+| **License** | Commercial API |
+| **Documentation** | [docs.speechmatics.com/voice-agents-flow](https://docs.speechmatics.com/voice-agents-flow) |
+| **GitHub** | [speechmatics/speechmatics-flow](https://github.com/speechmatics/speechmatics-flow) |
+
+---
+
+## Core Features
+
+- **End-to-end speech-to-speech pipeline**: STT, LLM, and TTS via a single API call.
+- **Smart turn detection**: uses a small language model (SLM) to decide when a speaker's turn has ended, reducing false triggers.
+- **Interruption handling**: ignores unintentional interruptions, handles intentional ones gracefully.
+- **Speaker locking**: isolates a target speaker and filters out background voices in multi-speaker environments.
+- **Function calling**: connects agents to external tools, APIs, databases, and validation services.
+- **Internet search**: agents can query live web data (weather, news) during conversations.
+- **55+ language support**: same multilingual coverage as Speechmatics' STT API.
+- **Conversation moderation**: real-time transcript analysis to flag or filter content.
+- **Flexible deployment**: private SaaS cloud or on-premises.
+- **Security**: ISO/IEC 27001:2022 certified, GDPR compliant.
+
+---
+
+## Pricing
+
+| Tier | Included |
+|------|----------|
+| Free | Up to 50 hours/month |
+| Enterprise | Custom pricing, contact Speechmatics |
+
+---
+
+## Tools and Resources
+
+- **[Flow API Reference](https://docs.speechmatics.com/flow-api-ref)**: full WebSocket and configuration reference.
+- **[Flow Python SDK](https://github.com/speechmatics/speechmatics-flow)**: Python client and CLI for building voice agents.
+- **[Flow Configuration Docs](https://docs.speechmatics.com/flow/config)**: LLM configuration, persona settings, and function calling setup.
+- **[Developer Portal](https://portal.speechmatics.com)**: API key management.
+
+---
+
+## Ecosystem and Integrations
+
+- Works with [Vapi](https://vapi.ai) for no-code voice agent deployments.
+- Works with [LiveKit](https://livekit.io) for WebRTC-based real-time infrastructure.
+- Works with [Pipecat](https://www.pipecat.ai) for open-source voice pipeline orchestration.
+- Supports contact center, healthcare, drive-thru, educational assistant, and smart device use cases.
+
+---
+
+Get started with the [free tier (50 hours/month)](https://docs.speechmatics.com/voice-agents-flow) or contact Speechmatics for enterprise access at flow-help@speechmatics.com.


### PR DESCRIPTION
## Summary

- Adds `technologies/speechmatics/index.mdx` — company index page covering founding story, core products, developer resources, and use cases
- Adds `technologies/speechmatics/speechmatics-api.mdx` — Speechmatics speech-to-text API (Ursa 2 model), accuracy benchmarks, pricing tiers, and SDK links
- Adds `technologies/speechmatics/speechmatics-flow.mdx` — Flow voice agent API announced July 2024, combining STT/LLM/TTS in a single pipeline

## Test plan

- [ ] Frontmatter present on all three files (`title`, `description`; `author` on sub-pages)
- [ ] No em dashes in body text
- [ ] No invented facts — all claims sourced from speechmatics.com and docs.speechmatics.com
- [ ] `<TechTutorials/>` present on `index.mdx`
- [ ] All URLs spot-checked (homepage, docs, GitHub, portal)
- [ ] File paths are kebab-case lowercase