### PR TITLE
feat: add Kraken sub-technology pages

### DIFF
--- a/technologies/kraken/ink.mdx
+++ b/technologies/kraken/ink.mdx
@@ -1,0 +1,87 @@
+---
+title: "Ink"
+author: "stevekimoi"
+description: "Ink is Kraken's EVM-compatible Layer-2 blockchain built on the OP Stack, offering 1-second block times, sub-cent transaction fees, and Superchain interoperability with Base, Soneium, and 29+ other chains."
+---
+
+# Ink
+
+[Ink](https://inkonchain.com) is Kraken's dedicated DeFi blockchain, built on the OP Stack (Optimism's open-source rollup framework) and operating as an optimistic rollup anchored to Ethereum. It bundles transactions off-chain and posts compressed proofs to Ethereum for final settlement, delivering 1-second block times, sub-cent fees, and full EVM equivalence. Ink is a member of the Superchain, sharing cross-chain messaging infrastructure with Base, Worldchain, Soneium, and 29+ other OP Stack chains.
+
+| General | |
+|---------|--|
+| **Developer** | Kraken (Payward Inc.) |
+| **Type** | EVM-compatible L2 (optimistic rollup) |
+| **Stack** | OP Stack (Optimism) |
+| **Chain ID** | 57073 |
+| **Native Currency** | ETH |
+| **License** | MIT (OP Stack) |
+| **Documentation** | [docs.inkonchain.com](https://docs.inkonchain.com) |
+| **GitHub** | [inkonchain/node](https://github.com/inkonchain/node) |
+| **Block Explorer** | [explorer.inkonchain.com](https://explorer.inkonchain.com) |
+
+---
+
+## Core Features
+
+- **EVM equivalence**: any Solidity contract that deploys on Ethereum deploys on Ink without modification.
+- **1-second block times**: with sub-second block production in active development.
+- **Sub-cent transaction fees**: significantly lower cost than Ethereum mainnet.
+- **EIP-7702 support**: compatible with Ethereum's account abstraction improvements.
+- **Superchain interoperability**: cross-chain communication with Base, Soneium, Worldchain, and 29+ chains.
+- **Self-hosted nodes**: run your own Ink node via the open-source node repository.
+
+---
+
+## Network Information
+
+**Mainnet:**
+
+| Parameter | Value |
+|-----------|-------|
+| Chain ID | 57073 |
+| RPC (HTTPS) | `https://rpc-gel.inkonchain.com` |
+| RPC (WSS) | `wss://rpc-gel.inkonchain.com` |
+| Alternate RPC | `https://rpc-qnd.inkonchain.com` |
+| Block Explorer | `https://explorer.inkonchain.com` |
+
+**Testnet (Ink Sepolia):**
+
+| Parameter | Value |
+|-----------|-------|
+| Chain ID | 763373 |
+| RPC (HTTPS) | `https://rpc-gel-sepolia.inkonchain.com` |
+| Alternate RPC | `https://rpc-qnd-sepolia.inkonchain.com` |
+| Block Explorer | `https://explorer-sepolia.inkonchain.com` |
+
+---
+
+## Developer Tooling
+
+- **Smart contract frameworks**: Foundry, Hardhat, and Remix are all documented and supported.
+- **Client libraries**: Ethers.js v6 and Viem (with `inkSepolia` chain config) work out of the box.
+- **Blockscout Explorer API**: REST and GraphQL available at [explorer.inkonchain.com/api-docs](https://explorer.inkonchain.com/api-docs).
+- **Third-party RPC**: QuickNode and dRPC support Ink with higher-throughput paid tiers.
+- **Testnet faucet**: available for testnet ETH to fund development and testing.
+
+---
+
+## Tools and Resources
+
+- **[Ink Documentation](https://docs.inkonchain.com)**: network info, developer guides, and tooling reference.
+- **[Ink Node](https://github.com/inkonchain/node)**: run a self-hosted Ink node.
+- **[Block Explorer](https://explorer.inkonchain.com)**: Blockscout-based explorer with API access.
+- **[Ink Docs GitHub](https://github.com/inkonchain/docs)**: open-source documentation repository.
+- **[Builder Program](https://inkonchain.com)**: grant opportunities for projects building on Ink.
+
+---
+
+## Ecosystem and Integrations
+
+- Member of the Optimism Superchain, sharing cross-chain messaging infrastructure with Base, Soneium, and Worldchain.
+- Standard Web3 tooling (MetaMask, Foundry, Hardhat) works immediately with Ink's public RPC endpoints.
+- Kraken's centralized exchange infrastructure integrates with Ink to let Kraken users bridge assets to DeFi without relinquishing custody.
+
+---
+
+Connect to Ink mainnet at `https://rpc-gel.inkonchain.com` (Chain ID: 57073) and start with the [Ink documentation](https://docs.inkonchain.com) to deploy your first contract.

--- a/technologies/kraken/kraken-cli.mdx
+++ b/technologies/kraken/kraken-cli.mdx
@@ -1,0 +1,79 @@
+---
+title: "Kraken CLI"
+author: "stevekimoi"
+description: "Kraken CLI is an open-source, single-binary command-line tool for interacting with Kraken's trading API, supporting spot, futures, xStocks, paper trading, real-time WebSocket streams, and a built-in MCP server for AI agent integration."
+---
+
+# Kraken CLI
+
+[Kraken CLI](https://github.com/krakenfx/kraken-cli) is an open-source command-line execution engine for Kraken's markets, launched on March 11, 2026. Built under the MIT license, it gives developers and AI agents direct access to market data, account management, and order execution across spot, futures, xStocks, and forex through 151 commands. It also ships a built-in Model Context Protocol (MCP) server, making it directly usable in AI coding tools like Claude Code, Cursor, and Gemini CLI.
+
+| General | |
+|---------|--|
+| **Released** | March 11, 2026 (v0.3.2 as of April 2026) |
+| **Developer** | Kraken (Payward Inc.) |
+| **Type** | Open-source CLI / MCP server |
+| **License** | MIT |
+| **GitHub** | [krakenfx/kraken-cli](https://github.com/krakenfx/kraken-cli) |
+| **Documentation** | [kraken.com/kraken-cli](https://www.kraken.com/kraken-cli) |
+
+---
+
+## Core Features
+
+- **151 commands** covering market data, account, trading, funding, futures, and WebSocket streaming.
+- **Paper trading**: sandbox mode using live prices with no real funds required and no Kraken account needed.
+- **Built-in MCP server**: launch with `kraken mcp` to expose commands as tools in any MCP-compatible AI agent.
+- **Real-time WebSocket streaming**: live tickers, order books, trades, and Level 3 data from the command line.
+- **50 pre-built Agent Skills** for common trading workflows, ready to use in any AI agent.
+- **Dead man's switch**: auto-cancels open orders on disconnect to prevent unintended exposure.
+- **Least-privilege API keys**: supports scoped API keys; secrets are never logged.
+- **Binary verification**: release binaries are signed with minisign for supply chain integrity.
+
+---
+
+## Command Groups
+
+| Group | Description |
+|-------|-------------|
+| Market Data | Ticker, order book, OHLC, recent trades, spreads (public, no auth) |
+| Account | Balances, open orders, trade history, ledgers, positions |
+| Trading | Buy/sell, batch orders, amend/cancel (spot, xStocks, forex) |
+| Funding | Deposits, withdrawals, wallet transfers |
+| Futures | Orders, positions, paper trading, all 8 order types |
+| WebSocket | Real-time streaming for tickers, trades, order books, Level 3 |
+| MCP Server | `kraken mcp` starts the MCP server over stdio |
+
+---
+
+## Installation
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/krakenfx/kraken-cli/releases/latest/download/kraken-cli-installer.sh | sh
+```
+
+Alternatively, install via Rust: `cargo install --git https://github.com/krakenfx/kraken-cli`
+
+Pre-built binaries for macOS and Linux are available on [GitHub Releases](https://github.com/krakenfx/kraken-cli/releases).
+
+---
+
+## Tools and Resources
+
+- **[GitHub Repository](https://github.com/krakenfx/kraken-cli)**: source code, releases, and issue tracker.
+- **[Kraken CLI Product Page](https://www.kraken.com/kraken-cli)**: official overview and getting started guide.
+- **[Kraken API Docs](https://docs.kraken.com)**: underlying REST and WebSocket API documentation.
+
+---
+
+## Ecosystem and Integrations
+
+- MCP server integrates natively with Claude Code, Cursor, GitHub Copilot, Gemini CLI, Goose, and Codex.
+- Paper trading mode works without a Kraken account for development and testing.
+- Live trading requires a Kraken account and API keys with appropriate permissions.
+- Public market data commands require no authentication and no account.
+
+---
+
+Install the CLI and run `kraken --help` to explore all commands, or `kraken mcp` to start the MCP server for AI agent access.

--- a/technologies/kraken/rest-api.mdx
+++ b/technologies/kraken/rest-api.mdx
@@ -1,0 +1,87 @@
+---
+title: "Kraken REST API"
+author: "stevekimoi"
+description: "Kraken's REST API provides programmatic access to spot and futures markets, account management, and order execution via HMAC-SHA512 authenticated HTTPS endpoints with a tiered rate limiting system."
+---
+
+# Kraken REST API
+
+The [Kraken REST API](https://docs.kraken.com/api/docs/guides/global-intro/) provides HTTP-based access to Kraken's spot and futures markets, account data, and trading operations. It covers public market data endpoints (no authentication required) and private endpoints for account management and order execution (HMAC-SHA512 authenticated). The API supports Spot, Futures, Custody, and Embed products, each with separate base URLs.
+
+| General | |
+|---------|--|
+| **Developer** | Kraken (Payward Inc.) |
+| **Type** | REST API |
+| **License** | Commercial API (free with Kraken account) |
+| **Documentation** | [docs.kraken.com](https://docs.kraken.com/api/docs/guides/global-intro/) |
+| **GitHub** | [krakenfx/api-go](https://github.com/krakenfx/api-go) |
+
+---
+
+## Core Features
+
+- **Public and private endpoints**: public market data requires no authentication; private endpoints use HMAC-SHA512 signing.
+- **Multiple product APIs**: Spot, Futures, Custody, and Embed each have dedicated endpoints.
+- **Tiered rate limiting**: per-API-key counter with decay rates based on account tier (Intermediate or Pro).
+- **Subaccount support**: master accounts can manage subaccounts programmatically.
+- **Earn and staking**: endpoints for managing yield-generating positions.
+
+---
+
+## Endpoints
+
+**Spot REST base URL:** `https://api.kraken.com/0/`
+
+| Category | Endpoints |
+|----------|-----------|
+| Public | Ticker, OHLC, order book, recent trades, spreads, asset pairs, system status |
+| Private: Account | Balance, trade balance, open/closed orders, trade history, ledger entries |
+| Private: Trading | Add order, amend order, cancel order, cancel all orders, batch orders |
+| Private: Funding | Deposit addresses, deposit methods, withdrawal info, withdraw funds |
+| Private: Earn | Staking and yield positions |
+
+---
+
+## Authentication
+
+Spot REST authentication uses HMAC-SHA512:
+
+1. Generate a nonce (always-increasing unsigned 64-bit integer; millisecond UNIX timestamps recommended)
+2. Compute: `SHA256(nonce + POST body data)`
+3. Compute: `HMAC-SHA512(URI path + SHA256 result, base64-decoded private key)`
+4. Send `API-Key` header (public key) and `API-Sign` header (base64-encoded HMAC result)
+
+The private key is never transmitted directly.
+
+---
+
+## Rate Limits (Spot REST)
+
+| Tier | Max Counter | Decay Rate |
+|------|-------------|------------|
+| Intermediate | 20 | 0.5 per second |
+| Pro | 20 | 1 per second |
+
+Ledger and trade history calls add 4 to the counter; all other private calls add 1. Order placement and cancellation use a separate trading rate limiter. Exceeding limits returns `EAPI:Rate limit exceeded`. Rate limits are shared across REST, WebSocket, and FIX for the same API key.
+
+---
+
+## Tools and Resources
+
+- **[API Reference Center](https://docs.kraken.com/api/docs/guides/global-intro/)**: full endpoint documentation for all products.
+- **[Official Go SDK](https://github.com/krakenfx/api-go)**: MIT-licensed, covers Spot and Derivatives REST and WebSocket.
+- **[Python SDK (community)](https://github.com/btschwertfeger/python-kraken-sdk)**: full-featured community SDK with async support and built-in WebSocket handlers.
+- **[Kraken CLI](https://github.com/krakenfx/kraken-cli)**: command-line access to REST endpoints without writing code.
+- **[REST Quickstart Examples](https://docs.kraken.com/api/docs/guides/spot-examples/)**: code samples for common operations.
+
+---
+
+## Ecosystem and Integrations
+
+- API keys are generated in Kraken account settings with configurable permissions (read-only, trading, funding).
+- Commercial redistribution of Kraken market data requires prior approval from marketdata@kraken.com.
+- Community SDKs available for Python, Go, C++, and Julia (listed in official documentation).
+
+---
+
+Generate API keys in your [Kraken account settings](https://www.kraken.com/u/security/api) and follow the [REST quickstart](https://docs.kraken.com/api/docs/guides/spot-examples/) to place your first programmatic order.

--- a/technologies/kraken/websocket-api.mdx
+++ b/technologies/kraken/websocket-api.mdx
@@ -1,0 +1,90 @@
+---
+title: "Kraken WebSocket API"
+author: "stevekimoi"
+description: "Kraken's WebSocket API v2 provides real-time market data streams (ticker, order book, trades) and private account feeds (executions, balances) for spot and futures markets."
+---
+
+# Kraken WebSocket API
+
+The [Kraken WebSocket API](https://docs.kraken.com/api/docs/guides/global-intro/) provides event-driven, real-time access to Kraken's spot and futures markets. Version 2 (v2) is the current API, offering public feeds for market data (no authentication required) and private authenticated feeds for account events and order management. WebSocket v2 consolidates order status and fill events into a single `executions` channel, replacing the separate streams from v1.
+
+| General | |
+|---------|--|
+| **Developer** | Kraken (Payward Inc.) |
+| **Type** | WebSocket API (real-time streaming) |
+| **License** | Commercial API (free with Kraken account) |
+| **Documentation** | [docs.kraken.com](https://docs.kraken.com) |
+| **GitHub** | [krakenfx/api-go](https://github.com/krakenfx/api-go) |
+
+---
+
+## Core Features
+
+- **Public feeds (no auth)**: ticker, order book (L2), and trade streams available without a Kraken account.
+- **Private authenticated feeds**: execution events, balance updates, and order management.
+- **Configurable order book depth**: 10, 25, 100, 500, or 1,000 levels with CRC32 checksum for integrity verification.
+- **Level 3 data**: per-order `orders` channel (authenticated) for full depth-of-market.
+- **Multi-symbol subscriptions**: subscribe to multiple instruments in a single message.
+- **Request/response correlation**: `req_id` field for matching responses to requests.
+- **Futures support**: separate WebSocket endpoint for futures market data and order management.
+
+---
+
+## Endpoints
+
+| Endpoint | URL |
+|----------|-----|
+| Public (spot, v2) | `wss://ws.kraken.com/v2` |
+| Private (spot, v2) | `wss://ws-auth.kraken.com/v2` |
+| Futures | `wss://futures.kraken.com/ws/v1` |
+| Colocation (spot) | `colo-london.vip-ws.kraken.com` |
+
+---
+
+## Public Channels
+
+| Channel | Description |
+|---------|-------------|
+| `ticker` | Best bid/offer, last trade price, 24h OHLCV, VWAP, and price change percentage |
+| `book` | Aggregated order book (L2) with configurable depth and CRC32 integrity checksum |
+| `trade` | Trade events with side, quantity, price, order type, trade ID, and RFC3339 timestamp |
+
+Snapshots are sent on subscription by default (`"snapshot": true`). The ticker channel supports `"bbo"` (best bid/offer changes) or `"trades"` as the event trigger.
+
+---
+
+## Private Channels (Authenticated)
+
+| Channel | Description |
+|---------|-------------|
+| `executions` | Order status updates and fill events (replaces v1 `openOrders` and `ownTrades`) |
+| `balances` | Account balance changes in real time |
+| User Trading | Add, amend, and cancel orders via WebSocket without a REST roundtrip |
+
+**Authentication for private feeds:**
+1. Call `GET /0/private/GetWebSocketsToken` via REST using your API credentials
+2. Use the returned token (valid 15 minutes) in the subscribe message
+3. Include the token as: `{"event": "subscribe", "subscription": {"name": "...", "token": "..."}}`
+
+---
+
+## Tools and Resources
+
+- **[WebSocket v2 Documentation](https://docs.kraken.com)**: full channel specs and message format reference.
+- **[Authentication Guide](https://docs.kraken.com/api/docs/guides/spot-ws-auth/)**: step-by-step WebSocket token generation.
+- **[Official Go SDK](https://github.com/krakenfx/api-go)**: covers Spot and Derivatives WebSocket connections.
+- **[Python SDK (community)](https://github.com/btschwertfeger/python-kraken-sdk)**: async WebSocket client with built-in reconnection handling.
+- **[Kraken CLI](https://github.com/krakenfx/kraken-cli)**: `kraken ws` commands for WebSocket streaming from the terminal.
+
+---
+
+## Ecosystem and Integrations
+
+- Rate limits are shared across REST, WebSocket, and FIX for the same API key.
+- Colocation endpoints are available via the Beeks Group for institutions requiring sub-millisecond access.
+- Commercial redistribution of market data streams requires prior approval from marketdata@kraken.com.
+- The official Go SDK supports both Spot and Derivatives WebSocket under a single import.
+
+---
+
+Subscribe to public feeds immediately at `wss://ws.kraken.com/v2` without any authentication. For private feeds, generate a WebSocket token first via the [REST token endpoint](https://docs.kraken.com/api/docs/guides/spot-ws-auth/).


### PR DESCRIPTION
## Summary

- Adds `technologies/kraken/kraken-cli.mdx` — open-source CLI launched March 2026, 151 commands, built-in MCP server for AI agent integration, paper trading
- Adds `technologies/kraken/rest-api.mdx` — Spot/Futures REST API covering authentication (HMAC-SHA512), rate limits by tier, and SDK options
- Adds `technologies/kraken/websocket-api.mdx` — WebSocket API v2 with public market data channels, private execution feeds, and token auth flow
- Adds `technologies/kraken/ink.mdx` — Kraken's OP Stack Layer-2 (Chain ID 57073), full mainnet/testnet network params, developer tooling

## Test plan

- [ ] Frontmatter present on all four files (`title`, `description`, `author`)
- [ ] No em dashes in body text
- [ ] No invented facts — all claims sourced from docs.kraken.com, github.com/krakenfx, and docs.inkonchain.com
- [ ] All URLs spot-checked
- [ ] File paths are kebab-case lowercase