### PR TITLE
feat: This Week in AI recap — May 11-18, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-05-18.mdx
+++ b/blog/en/this-week-in-ai-2026-05-18.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenAI launches ChatGPT ads, Anthropic posts 80x revenue growth, US finalizes AI oversight"
-description: "OpenAI launched ChatGPT ads, Anthropic disclosed 80x revenue growth, and the US finalized AI pre-deployment oversight with all five major labs in May 2026."
+description: "AI news, May 2026: OpenAI launched ChatGPT ads, Anthropic disclosed 80x revenue growth, and the US finalized pre-deployment oversight with all five major labs."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/66b9a755-b99e-4219-11c0-3100872c7300/public"
 authorUsername: "stevekimoi"
 ---
@@ -47,7 +47,7 @@ Anthropic launched Claude for Small Business this week, shipping ready-to-run wo
 
 ### Claude Code: parallel agents and a new desktop
 
-Anthropic shipped a multi-agent upgrade to Claude Code, with a [redesigned desktop interface](https://www.thedeepview.com/articles/anthropic-gives-claude-code-a-multi-agent-upgrade) that includes a sidebar for managing multiple sessions, drag-and-drop rearranging, and an integrated terminal and file editor. You can now run parallel agents from a single interface rather than managing them manually. If you are building with Claude Code, it is worth updating before your next project.
+Anthropic shipped a multi-agent upgrade to Claude Code, with a [redesigned desktop interface](https://www.thedeepview.com/articles/anthropic-gives-claude-code-a-multi-agent-upgrade) that includes a sidebar for managing multiple sessions, drag-and-drop rearranging, and an integrated terminal and file editor. You can now run parallel agents from a single interface rather than managing them manually. If you are building with Claude Code for your next [AI hackathon](https://lablab.ai/event) or side project, it is worth updating before you start.
 
 ---
 

--- a/blog/en/this-week-in-ai-2026-05-18.mdx
+++ b/blog/en/this-week-in-ai-2026-05-18.mdx
@@ -1,0 +1,72 @@
+---
+title: "OpenAI launches ChatGPT ads, Anthropic posts 80x revenue growth, US finalizes AI oversight"
+description: "OpenAI launched ChatGPT ads, Anthropic disclosed 80x revenue growth, and the US finalized AI pre-deployment oversight with all five major labs in May 2026."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/66b9a755-b99e-4219-11c0-3100872c7300/public"
+authorUsername: "stevekimoi"
+---
+
+# OpenAI launches ChatGPT ads, Anthropic posts 80x revenue growth, US finalizes AI oversight
+
+*This Week in AI, May 11-18, 2026*
+
+Three things happened this week that, taken together, suggest the AI industry is moving from land-grab to institution: OpenAI started selling ads, Anthropic started posting numbers, and the US government stopped asking nicely.
+
+## Key Takeaways
+
+- **OpenAI goes ad-supported:** ChatGPT now has a self-serve ad platform, a direct signal that OpenAI is building a media business alongside its AI one. Builders should expect sponsored answers to become a factor in how the product shapes up.
+- **Anthropic's 80x revenue jump:** Anthropic [disclosed Q1 2026 revenue grew 80x year-over-year](https://www.cnbc.com/2026/04/29/anthropic-weighs-raising-funds-at-900b-valuation-topping-openai.html), the clearest signal yet that Claude has real enterprise traction. The company is now in talks to raise at a $900B valuation.
+- **Claude for Small Business:** Anthropic plugged Claude into QuickBooks, PayPal, HubSpot, and Google Workspace this week. If you build tools for SMBs, Claude is now a direct competitor in your market.
+- **Government oversight is live:** The US Commerce Department's CAISI finalized pre-deployment evaluation [agreements with all five major frontier labs](https://www.cnbc.com/2026/05/05/ai-oversight-trump-google-microsoft-xai.html). Every major model now passes through government evaluation before public launch.
+- **Claude Code gets parallel agents:** Anthropic shipped a multi-agent upgrade to Claude Code that lets you run parallel tasks from a redesigned desktop interface with a new sidebar, drag-and-drop session management, and an integrated terminal.
+
+---
+
+## OpenAI Plays Offense
+
+### ChatGPT gets a self-serve ad platform
+
+OpenAI launched a self-serve ad platform for ChatGPT this week, the first time the company has directly monetized through advertising. The move mirrors what Google did with search in the early 2000s: build the audience, then build the monetization layer on top. For developers building on top of ChatGPT, this changes the calculus on how the model behaves in certain product contexts.
+
+OpenAI also [launched the OpenAI Deployment Company](https://openai.com/news/) on May 11, a separate entity aimed at helping businesses build around intelligence at scale. The two moves together suggest OpenAI is structuring for longevity, not just growth.
+
+### GPT-5.5 Instant holds down the fort
+
+GPT-5.5 Instant, which became ChatGPT's default on May 5, now [integrates memory across past conversations, uploaded files, and Gmail](https://techdg.in/latest-ai-updates-may-2026-global-ai-news-trends/). It is a useful product improvement. It is also the model OpenAI is using to hold ground while Anthropic has a breakout week.
+
+---
+
+## Anthropic's Breakout Week
+
+### 80x revenue growth and a $900B raise
+
+Anthropic disclosed that Q1 2026 revenue [grew 80x year-over-year](https://www.cnbc.com/2026/04/29/anthropic-weighs-raising-funds-at-900b-valuation-topping-openai.html) and is now in talks with investors to raise at a $900 billion valuation, higher than OpenAI's last round. The numbers confirm what enterprise procurement data has been suggesting for months: Claude is the model businesses actually deploy.
+
+### Claude for Small Business
+
+Anthropic launched Claude for Small Business this week, shipping ready-to-run workflows for payroll, invoicing, sales, and month-end close [inside QuickBooks, PayPal, HubSpot, Canva, Docusign, Google Workspace, and Microsoft 365](https://releasebot.io/updates/anthropic). The play is clear: make Claude the default AI inside the tools 50 million small businesses already use, before those businesses make a deliberate model choice.
+
+### Claude Code: parallel agents and a new desktop
+
+Anthropic shipped a multi-agent upgrade to Claude Code, with a [redesigned desktop interface](https://www.thedeepview.com/articles/anthropic-gives-claude-code-a-multi-agent-upgrade) that includes a sidebar for managing multiple sessions, drag-and-drop rearranging, and an integrated terminal and file editor. You can now run parallel agents from a single interface rather than managing them manually. If you are building with Claude Code, it is worth updating before your next project.
+
+---
+
+## The Regulation Question
+
+### Every major lab is now under government evaluation
+
+The US Commerce Department's CAISI finalized pre-deployment evaluation [agreements with all five major frontier AI labs: OpenAI, Anthropic, Google DeepMind, Microsoft, and xAI](https://www.cnbc.com/2026/05/05/ai-oversight-trump-google-microsoft-xai.html). No major model goes public without passing through this process. This is the most significant structural change to AI governance since the 2023 executive order, and it will slow release timelines in ways that are not fully visible yet.
+
+---
+
+## Quick Hits
+
+- **NVIDIA Nemotron 3:** NVIDIA released Nemotron 3 as open-source models in Nano, Super, and Ultra sizes, [optimized for agentic AI applications](https://nvidianews.nvidia.com/news/nvidia-debuts-nemotron-3-family-of-open-models). Nano delivers 4x higher throughput than its predecessor.
+- **SubQ:** A new LLM built on subquadratic sparse attention shipped this week, with a [12 million token context window at roughly one-fifth the cost of frontier models](https://llm-stats.com/llm-updates). Worth watching if you are building on long-context workloads.
+- **Meta's Avocado is late:** Meta's next model was expected in May. [Internal testing placed it between Gemini 2.5 and 3.0](https://techdg.in/latest-ai-updates-may-2026-global-ai-news-trends/), below competitive benchmarks. With Google I/O on May 19 set to announce a new Gemini model, June is now the likeliest window for Meta.
+- **DeepSeek V4 Flash and Pro:** DeepSeek released both V4 Flash and V4 Pro as [open-source models](https://llm-stats.com/ai-news) this week, with strong coding benchmarks. Worth testing if you are on the open-source track.
+- **MCP hits 97M installs:** Anthropic's Model Context Protocol crossed [97 million installs](https://releasebot.io/updates/anthropic), with every major AI provider now shipping MCP-compatible tooling.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*


### PR DESCRIPTION
## Summary

- Weekly AI news recap covering May 11-18, 2026
- Top stories: OpenAI ChatGPT ad platform, Anthropic 80x Q1 revenue growth + Claude for Small Business, US government CAISI oversight finalized, Claude Code multi-agent upgrade, NVIDIA Nemotron 3, SubQ model
- Cover image uploaded to Cloudflare Images

## Test plan

- [ ] Preview article on staging
- [ ] Share social brief with Gosia + Soto
- [ ] Verify all source links are live