### PR TITLE
Build a Startup Research Agent for AI Hackathons with Bright Data & Claude API

### DIFF
--- a/.agents/skills/content-start/SKILL.md
+++ b/.agents/skills/content-start/SKILL.md
@@ -56,6 +56,18 @@ Present:
 
 Wait for user confirmation before proceeding to draft.
 
+### 5b. Build a working prototype (tutorials with code only)
+
+Before writing a single word of the tutorial article:
+
+1. Create the project directory under `/Users/la/lablab-ai/[slug]/`
+2. Build the full end-to-end implementation — all code must run without errors
+3. Verify the golden path works (real API calls, real output)
+4. Note any gotchas, non-obvious config steps, or error patterns encountered — these become the most valuable parts of the tutorial
+5. Only proceed to writing once the prototype works end-to-end
+
+This step is mandatory for all tutorials. Do not start drafting until the code is confirmed working.
+
 ### 6. Set Notion task to In Progress
 
 Update the Notion task status to `In Progress`.
@@ -69,6 +81,7 @@ Confirm the following are locked before writing begins:
 - [ ] Sources gathered
 - [ ] Notion task is `In Progress`
 - [ ] File location decided: `articles/[slug].md` or `tutorials/[slug]/article.md`
+- [ ] Working prototype built and verified at `/Users/la/lablab-ai/[slug]/` (tutorials only)
 
 ## Content type reminders
 

--- a/.agents/skills/prototype-ship/SKILL.md
+++ b/.agents/skills/prototype-ship/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: prototype-ship
+description: Build a working prototype, verify it end-to-end, create a GitHub repo, commit each file individually with a descriptive message, build a web UI frontend, and push everything. Use whenever a tutorial prototype is ready to be shipped to GitHub.
+compatibility: Designed for Claude Code. Requires gh CLI authenticated as Stephen-Kimoi.
+---
+
+## Steps
+
+### 1. Verify the prototype works end-to-end
+
+Before touching git:
+- Run the core script manually and confirm it produces real output
+- Fix any errors until a clean run completes
+- Note any gotchas encountered — these are tutorial gold
+
+### 2. Build a web UI (if not already present)
+
+Every prototype needs a UI that non-technical people can understand.
+
+**Required files:**
+- `agent.py` (or equivalent) — refactor to expose a **generator/stream interface** alongside the CLI interface. The generator yields typed event dicts: `{"type": "tool_call"|"tool_result"|"thinking"|"report"|"error", ...}`
+- `app.py` — Flask server with a **Server-Sent Events (SSE) endpoint** that wraps the generator
+- `templates/index.html` — single-page UI with:
+  - Input field + submit button
+  - Live **activity feed** panel (shows tool calls streaming in real time)
+  - **Output/report panel** (renders markdown with marked.js or similar)
+  - Stats bar (counts of tool calls, searches, scrapes, etc.)
+- `requirements.txt` — must include `flask>=3.0.0`
+
+**UI design standards:**
+- Dark theme (`#0f0f13` background)
+- Accent color: `#7c6aff` (purple) for primary actions, `#06b6d4` (cyan) for secondary
+- Animated dot indicator while agent is running
+- Activity items animate in with `slideIn` keyframe
+- Markdown rendered in the report panel — use `marked.js` from CDN
+- No frontend framework — vanilla JS only
+
+**Smoke test the UI before committing:**
+```bash
+source venv/bin/activate && python app.py &
+sleep 2 && curl -s http://localhost:5000 | head -3
+kill %1
+```
+
+### 3. Create the GitHub repository
+
+```bash
+gh repo create Stephen-Kimoi/<repo-slug> \
+  --public \
+  --description "<one-line description>"
+```
+
+Then:
+```bash
+git init
+git config user.name "Steve Kimoi"
+git config user.email "stephen.kimoi@nativelyai.com"
+git remote add origin https://github.com/Stephen-Kimoi/<repo-slug>.git
+git branch -M main
+```
+
+### 4. Commit each file individually
+
+Commit in this order, one file per commit:
+
+| File | Commit message pattern |
+|---|---|
+| `.gitignore` | `Add .gitignore` + what it excludes |
+| `requirements.txt` | `Add requirements.txt` + list the key deps and why |
+| Core logic file (e.g. `agent.py`) | `Add <file> — <one-line role>` + what it implements and how |
+| Server file (e.g. `app.py`) | `Add <file> — <one-line role>` + what the endpoint does |
+| `templates/index.html` | `Add templates/index.html — frontend UI` + what it shows |
+| `README.md` | `Add README.md` + what it covers |
+
+**Commit message rules:**
+- Subject line: `Add <filename> — <role>` (imperative, under 72 chars)
+- Body: 2–4 lines explaining what the file does and any non-obvious decisions
+- No `Co-Authored-By` lines
+- No "Generated with Claude" footers
+
+### 5. Write the README
+
+The README must include:
+- [ ] What the project does (2–3 sentences)
+- [ ] Architecture diagram (ASCII, showing data flow)
+- [ ] Project file structure with one-line descriptions
+- [ ] Prerequisites (accounts, tools needed)
+- [ ] Full setup steps (clone → venv → pip install → .env → run)
+- [ ] How the core loop works (simplified code snippet)
+- [ ] Example output
+- [ ] Ideas for extending the project
+- [ ] Built-with table
+
+### 6. Push
+
+```bash
+git push -u origin main
+```
+
+### 7. Hand off
+
+Confirm:
+- [ ] Prototype runs end-to-end without errors
+- [ ] UI serves at `localhost:5000` and streams live tool calls
+- [ ] All files committed individually with descriptive messages
+- [ ] README covers architecture + full setup
+- [ ] Repo is public at `https://github.com/Stephen-Kimoi/<repo-slug>`
+- [ ] Ready to write the tutorial (proceed to drafting)

--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -26,6 +26,7 @@ Read the full draft file.
 - [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: use the Cloudflare Images API with the `CLOUDFLARE_IMAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from `.agents/skills/.env`.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
+- [ ] **No em dashes** — scan the full body for `—` and replace with commas, colons, periods, or parentheses. This is a hard rule that applies to every piece.
 
 #### For articles only:
 
@@ -44,7 +45,8 @@ Read the full draft file.
 - [ ] **Prerequisites section present** — tools, API keys, framework versions listed
 - [ ] **`.env` format shown** (if needed) — with placeholder values, never real keys
 - [ ] **Final output shown** — screenshot, terminal output, or demo of the working result
-- [ ] **File saved in** `tutorials/[slug]/article.md`
+- [ ] **File saved as** `tutorials/en/[slug].mdx` — a single flat file, never a folder with `article.mdx` inside
+- [ ] **GitHub line references on all code excerpts** — every code block that references a project file must include a link like `Full implementation in [\`agent.py\`, lines 74-97](https://github.com/...#L74-L97):` immediately before the block. Do not use `# from file.py` comments as a substitute.
 
 ### 4. Report results
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Five agent skills live in `.agents/skills/` and cover the full content lifecycle
 | [`publish-check`](.agents/skills/publish-check/SKILL.md) | When a draft is complete — runs the full publishing checklist and updates Notion to Done |
 | [`seo-apply`](.agents/skills/seo-apply/SKILL.md) | After a draft passes publish-check — reads this week's Notion SEO clusters and applies surgical keyword improvements without changing tone |
 | [`weekly-ai-recap`](.agents/skills/weekly-ai-recap/SKILL.md) | Every Monday — researches the week's top AI news, writes the recap article, produces the social post brief |
+| [`prototype-ship`](.agents/skills/prototype-ship/SKILL.md) | After a working prototype is built — adds a web UI frontend, commits each file individually with descriptive messages, creates the GitHub repo, and pushes |
 
 ## Notion
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is the Lablab community-content repo. It contains all published articles, t
 
 ```
 blog/en/          — Articles (MDX)
-tutorials/        — Tutorial articles (MDX)
+tutorials/en/     — Tutorial articles (MDX) — single flat files: tutorials/en/[slug].mdx (never a folder)
 technologies/     — Technology index pages
 topics/           — Topic index pages
 ```
@@ -17,6 +17,7 @@ topics/           — Topic index pages
 
 - **Frontmatter required on every file:** `title`, `description`, `image`, `authorUsername`
 - **Images must use Cloudflare Images:** all image URLs must be `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no hotlinked external images, no Cloudinary URLs
+- **No em dashes in body text:** replace `—` with commas, colons, periods, or parentheses throughout
 - **Cloudflare Images account hash:** `K11gkZF3xaVyYzFESMdWIQ` (API token in `.agents/skills/.env` as `CLOUDFLARE_IMAGES_TOKEN`)
 - **Author username:** `stevekimoi`
 - **SEO guidelines:** see `SEO_GUIDELINES.md` for keyword strategy and frontmatter formatting rules

--- a/tutorials/en/claude-bright-data-research-agent.mdx
+++ b/tutorials/en/claude-bright-data-research-agent.mdx
@@ -1,22 +1,22 @@
 ---
 title: "Build a Startup Research Agent for AI Hackathons with Claude API"
 description: "AI hackathon tutorial: build a startup research agent with Claude API and Bright Data that searches, scrapes, and returns a structured report automatically."
-image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-ui-overview/public"
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-cover/public"
 authorUsername: "stevekimoi"
 ---
 
 ## Introduction
 
-Every existing Bright Data tutorial that uses Claude does it the same way: open Claude Desktop, configure an MCP server, and chat with it. That approach is fine for exploration, but it is not something you can ship.
+Type a company name. In under two minutes you have a structured research report: founders, funding history, business model, and this week's news, every data point fetched from live web sources at the moment you ask.
 
-This kind of deployable research agent is exactly what judges want to see at **AI hackathons** — something that runs end-to-end, not a chat session. If you're looking for a live competition to build and submit this kind of project, check out [upcoming AI hackathons on Lablab.ai](https://lablab.ai/event) where live web data challenges run regularly.
+This is what this agent produces. It runs the Claude API's tool-use loop, firing parallel Google searches through Bright Data's SERP API and scraping the most useful pages with Web Unlocker, then synthesizing everything into a markdown report. No chat session, no manual steps, no training-data cutoff.
 
-This tutorial takes a different path. You will build a fully programmatic research agent using the **Claude API** directly, with Bright Data's **SERP API** and **Web Unlocker** wired in as tools. The result is a deployable Python application. Give it a company name and it returns a structured research report covering founders, funding, business model, and recent news — no browser, no chat UI, no manual steps.
+This kind of agent is exactly what judges want to see at **AI hackathons**: something that runs end-to-end. If you're looking for a live competition to build and submit this, check out [upcoming AI hackathons on Lablab.ai](https://lablab.ai/event) where live web data challenges run regularly.
 
 By the end you will have:
 - A working agent that drives itself through a tool-use loop
-- A live web interface that streams the agent's activity in real time
-- A clear understanding of how to wire any data source into Claude's tool system
+- A streaming web UI that makes the agent's activity visible in real time
+- A clear pattern for wiring any data source into Claude's tool system
 
 The full source code is on [GitHub](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent).
 
@@ -29,7 +29,7 @@ The full source code is on [GitHub](https://github.com/Stephen-Kimoi/claude-brig
 
 ## Step 1: Set up your Bright Data zones
 
-Bright Data organises its APIs into **zones** — named configurations you create in the dashboard. You need two: one for search, one for scraping.
+Bright Data organises its APIs into **zones**: named configurations you create in the dashboard. You need two, one for search and one for scraping.
 
 **Create the SERP API zone**
 
@@ -66,12 +66,13 @@ UNLOCKER_ZONE=web_unlocker1
 
 The agent has two tools it can call. Both hit the same Bright Data REST endpoint (`https://api.brightdata.com/request`) using your API key as a Bearer token. What changes is the `zone` and `url` in the request body.
 
-**`search_web` — SERP API**
+**`search_web`: SERP API**
 
-Sends a Google search URL to Bright Data. The response is a structured JSON object with `organic` results containing title, URL, and snippet for each result. No proxy setup, no headless browser — one HTTP call returns clean search data.
+Sends a Google search URL to Bright Data. The response is a structured JSON object with `organic` results containing title, URL, and snippet for each result. No proxy setup, no headless browser. One HTTP call returns clean search data.
+
+Full implementation in [`agent.py`, lines 74-97](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent/blob/main/agent.py#L74-L97):
 
 ```python
-# from agent.py
 def search_web(query: str) -> str:
     search_url = f"https://www.google.com/search?q={requests.utils.quote(query)}&hl=en&gl=us"
     payload = {"zone": SERP_ZONE, "url": search_url, "format": "json"}
@@ -81,12 +82,13 @@ def search_web(query: str) -> str:
     return "\n".join(f"{r['title']}: {r['url']}\n{r.get('description','')}" for r in organic[:5])
 ```
 
-**`scrape_url` — Web Unlocker**
+**`scrape_url`: Web Unlocker**
 
 Sends any target URL to Bright Data. The Web Unlocker handles proxy rotation, CAPTCHA solving, and JavaScript rendering automatically. You receive the raw HTML back, which the function strips of tags before returning the text to Claude.
 
+Full implementation in [`agent.py`, lines 100-117](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent/blob/main/agent.py#L100-L117):
+
 ```python
-# from agent.py
 def scrape_url(url: str) -> str:
     payload = {"zone": UNLOCKER_ZONE, "url": url, "format": "raw"}
     r = requests.post(BRIGHT_DATA_ENDPOINT, headers=BD_HEADERS, json=payload, timeout=45)
@@ -101,7 +103,7 @@ def scrape_url(url: str) -> str:
 
 This is the core of the agent. Claude's tool-use works as a loop: you send a message, Claude either returns a final answer or requests one or more tool calls, you execute the tools and send the results back, and the loop continues until Claude signals it is done.
 
-The tool definitions tell Claude what each tool does and what inputs to provide:
+The tool definitions tell Claude what each tool does and what inputs to provide. Full definition in [`agent.py`, lines 24-59](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent/blob/main/agent.py#L24-L59):
 
 ```python
 TOOLS = [
@@ -130,7 +132,7 @@ TOOLS = [
 ]
 ```
 
-The agent loop:
+The agent loop. Full implementation in [`agent.py`, lines 135-183](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent/blob/main/agent.py#L135-L183):
 
 ```python
 messages = [{"role": "user", "content": f"Research this startup: {company_name}"}]
@@ -145,10 +147,10 @@ while True:
     )
 
     if response.stop_reason == "end_turn":
-        # Claude finished — the report is in response.content
+        # Claude finished; the report is in response.content
         return response
 
-    # Claude called tools — execute each one and return the results
+    # Claude called tools; execute each one and return the results
     tool_results = []
     for block in response.content:
         if block.type != "tool_use":
@@ -168,7 +170,7 @@ while True:
     # loop continues
 ```
 
-The key detail is `stop_reason`. When it equals `"tool_use"`, Claude is asking you to run tools. When it equals `"end_turn"`, it has finished and the final report is in the response. Everything else is just shuttling data back and forth.
+The key detail is `stop_reason`. When it equals `"tool_use"`, Claude is asking you to run tools. When it equals `"end_turn"`, it has finished and the final report is in the response. Everything else is shuttling data back and forth.
 
 ## Step 5: Run the agent from the terminal
 
@@ -239,7 +241,7 @@ The first thing that appears is the Company Overview table with factual fields p
 
 ![The report panel showing the Company Overview table for OpenAI with legal name, type, founding date, headquarters, revenue, and valuation](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-overview/public)
 
-Notice the data quality: `$730 billion (pre-money, Feb 2026 round)` and `~$13.1 billion` revenue came from pages the agent scraped during the run — not from Claude's training data. Bright Data's Web Unlocker retrieved that content at the time you made the request.
+Notice the data quality: `$730 billion (pre-money, Feb 2026 round)` and `~$13.1 billion` revenue came from pages the agent scraped during the run, not from Claude's training data. Bright Data's Web Unlocker retrieved that content at the time you made the request.
 
 Scrolling down, the Founders section shows a structured table with role and current status for each member of OpenAI's original 11-person founding team.
 
@@ -263,7 +265,7 @@ Here is what the full workspace looks like with both panels active simultaneousl
 
 ## How the streaming works
 
-The web UI receives the agent's progress in real time via **Server-Sent Events (SSE)**. The Flask endpoint wraps the `run_agent_stream()` generator and converts each yielded event into a SSE `data:` line:
+The web UI receives the agent's progress in real time via **Server-Sent Events (SSE)**. The Flask endpoint wraps the `run_agent_stream()` generator and converts each yielded event into a SSE `data:` line. Full implementation in [`app.py`, lines 13-31](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent/blob/main/app.py#L13-L31):
 
 ```python
 @app.route("/research", methods=["POST"])
@@ -278,11 +280,11 @@ def research():
     return Response(stream_with_context(generate()), mimetype="text/event-stream")
 ```
 
-The frontend uses `fetch` with a `ReadableStream` reader rather than `EventSource` because the endpoint uses POST. Each chunk is decoded, split on newlines, and parsed as JSON. The event `type` field controls what gets rendered — search queries go to the activity feed, the final `report` type populates the markdown panel.
+The frontend uses `fetch` with a `ReadableStream` reader rather than `EventSource` because the endpoint uses POST. Each chunk is decoded, split on newlines, and parsed as JSON. The event `type` field controls what gets rendered: search queries go to the activity feed, the final `report` type populates the markdown panel.
 
 ## What to try next
 
-**Research a newer, less-documented startup.** Try searching for Udio or Reflection AI. The agent will produce a thinner report with more approximate figures and more fallback searches. This is expected behaviour and useful to understand — the tool results are only as rich as the publicly available data.
+**Research a newer, less-documented startup.** Try searching for Udio or Reflection AI. The agent will produce a thinner report with more approximate figures and more fallback searches. This is expected behaviour and useful to understand. The tool results are only as rich as the publicly available data.
 
 **Research a company with an ambiguous name.** Try "Linear" or "Hex". Watch how Claude disambiguates using search snippets before committing to scraping specific pages.
 
@@ -293,16 +295,16 @@ The frontend uses `fetch` with a `ReadableStream` reader rather than `EventSourc
 ## Frequently Asked Questions
 
 **Q: Can I use this agent as the foundation for an AI hackathon project?**
-Yes. The agent is a deployable Python application — clone the repo, swap in your API credentials, and you have a working data pipeline within an hour. The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) on Lablab.ai uses exactly this kind of live-web research agent as a reference implementation for Track 1.
+Yes. The agent is a deployable Python application: clone the repo, swap in your API credentials, and have a working data pipeline within an hour. The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) on Lablab.ai uses exactly this kind of live-web research agent as a reference implementation for Track 1.
 
 **Q: Do I need prior Bright Data experience to follow this tutorial?**
-No. The tutorial walks through creating the two required zones (SERP API and Web Unlocker) from scratch. The only prerequisite is a Bright Data account — a free trial is available.
+No. The tutorial walks through creating the two required zones (SERP API and Web Unlocker) from scratch. The only prerequisite is a Bright Data account (a free trial is available).
 
 **Q: What happens if the agent can't find information about a company?**
 The agent degrades gracefully. For less-documented companies, Claude produces a thinner report with more approximate figures and more fallback searches. The "What to try next" section covers how to interpret these cases.
 
 **Q: How many tool calls does a typical research run make?**
-For a well-documented company like OpenAI, expect 14–16 tool calls across 6 searches and 8 scraped pages. For a newer startup with limited public information, the agent typically makes 8–10 calls before writing the report.
+For a well-documented company like OpenAI, expect 14-16 tool calls across 6 searches and 8 scraped pages. For a newer startup with limited public information, the agent typically makes 8-10 calls before writing the report.
 
 **Q: Can I add more data sources beyond Google search and web scraping?**
 Yes. Any HTTP call can become a Claude tool. The "What to try next" section outlines how to add a LinkedIn scraper or a Crunchbase-specific tool by following the same pattern used for `search_web` and `scrape_url`.
@@ -311,6 +313,6 @@ Yes. Any HTTP call can become a Claude tool. The "What to try next" section outl
 
 The difference between this agent and a Claude Desktop MCP setup is that this one is a Python process you control. It has no GUI dependency, no chat session to manage, and no manual steps between input and output. You can call `run_agent("Stripe")` from any Python script, schedule it as a cron job, or wrap it in a REST API.
 
-That is what the Claude API's tool use system enables: Claude as an orchestration layer that decides which data to fetch and when, while you control the tools it calls. Bright Data handles the hard parts of live web access — proxy rotation, CAPTCHA solving, anti-bot bypass — so the agent can read any public page without infrastructure work on your end.
+That is what the Claude API's tool use system enables: Claude as an orchestration layer that decides which data to fetch and when, while you control the tools it calls. Bright Data handles the hard parts of live web access: proxy rotation, CAPTCHA solving, and anti-bot bypass, so the agent can read any public page without infrastructure work on your end.
 
-The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) Track 1 asks builders to create agents that research and analyse companies using live web data. This project is a direct starting point for that track — clone the repo, swap in your credentials, and extend it with the data sources your use case needs.
+The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) Track 1 asks builders to create agents that research and analyse companies using live web data. This project is a direct starting point for that track. Clone the repo, swap in your credentials, and extend it with the data sources your use case needs.

--- a/tutorials/en/claude-bright-data-research-agent/article.mdx
+++ b/tutorials/en/claude-bright-data-research-agent/article.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Build a Startup Research Agent with Claude API and Bright Data"
-description: "Learn how to build a fully programmatic startup research agent using Claude's tool use feature and Bright Data's SERP API and Web Unlocker. The agent searches the web, scrapes live pages, and produces a structured research report automatically."
+title: "Build a Startup Research Agent for AI Hackathons with Claude API"
+description: "AI hackathon tutorial: build a startup research agent with Claude API and Bright Data that searches, scrapes, and returns a structured report automatically."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-ui-overview/public"
 authorUsername: "stevekimoi"
 ---
@@ -8,6 +8,8 @@ authorUsername: "stevekimoi"
 ## Introduction
 
 Every existing Bright Data tutorial that uses Claude does it the same way: open Claude Desktop, configure an MCP server, and chat with it. That approach is fine for exploration, but it is not something you can ship.
+
+This kind of deployable research agent is exactly what judges want to see at **AI hackathons** — something that runs end-to-end, not a chat session. If you're looking for a live competition to build and submit this kind of project, check out [upcoming AI hackathons on Lablab.ai](https://lablab.ai/event) where live web data challenges run regularly.
 
 This tutorial takes a different path. You will build a fully programmatic research agent using the **Claude API** directly, with Bright Data's **SERP API** and **Web Unlocker** wired in as tools. The result is a deployable Python application. Give it a company name and it returns a structured research report covering founders, funding, business model, and recent news — no browser, no chat UI, no manual steps.
 
@@ -53,7 +55,7 @@ pip install -r requirements.txt
 
 Create a `.env` file in the project root with your credentials:
 
-```
+```text
 ANTHROPIC_API_KEY=your_anthropic_api_key
 BRIGHT_DATA_API_KEY=your_bright_data_api_key
 SERP_ZONE=serp_api2
@@ -69,13 +71,14 @@ The agent has two tools it can call. Both hit the same Bright Data REST endpoint
 Sends a Google search URL to Bright Data. The response is a structured JSON object with `organic` results containing title, URL, and snippet for each result. No proxy setup, no headless browser — one HTTP call returns clean search data.
 
 ```python
+# from agent.py
 def search_web(query: str) -> str:
     search_url = f"https://www.google.com/search?q={requests.utils.quote(query)}&hl=en&gl=us"
     payload = {"zone": SERP_ZONE, "url": search_url, "format": "json"}
     resp = requests.post(BRIGHT_DATA_ENDPOINT, headers=BD_HEADERS, json=payload, timeout=30)
     body = json.loads(resp.json()["body"])
     organic = body.get("organic", [])
-    # format and return results...
+    return "\n".join(f"{r['title']}: {r['url']}\n{r.get('description','')}" for r in organic[:5])
 ```
 
 **`scrape_url` — Web Unlocker**
@@ -83,6 +86,7 @@ def search_web(query: str) -> str:
 Sends any target URL to Bright Data. The Web Unlocker handles proxy rotation, CAPTCHA solving, and JavaScript rendering automatically. You receive the raw HTML back, which the function strips of tags before returning the text to Claude.
 
 ```python
+# from agent.py
 def scrape_url(url: str) -> str:
     payload = {"zone": UNLOCKER_ZONE, "url": url, "format": "raw"}
     r = requests.post(BRIGHT_DATA_ENDPOINT, headers=BD_HEADERS, json=payload, timeout=45)
@@ -176,7 +180,7 @@ python agent.py "OpenAI"
 
 You will see live output as the agent works, with each tool call logged:
 
-```
+```text
 Researching: OpenAI
 ==================================================
 [Tool: search_web] {"query": "OpenAI startup overview founding history"}
@@ -285,6 +289,23 @@ The frontend uses `fetch` with a `ReadableStream` reader rather than `EventSourc
 **Add a third tool.** The pattern extends naturally. You could add a `search_linkedin` tool that calls Bright Data's LinkedIn scraper, or a `get_crunchbase` tool that hits a specific Crunchbase URL. Any HTTP call can become a tool.
 
 **Export the report.** The final report string is plain markdown. You can write it to a file, push it to Notion via their API, or parse it with another Claude call to extract structured fields like funding amounts into a database.
+
+## Frequently Asked Questions
+
+**Q: Can I use this agent as the foundation for an AI hackathon project?**
+Yes. The agent is a deployable Python application — clone the repo, swap in your API credentials, and you have a working data pipeline within an hour. The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) on Lablab.ai uses exactly this kind of live-web research agent as a reference implementation for Track 1.
+
+**Q: Do I need prior Bright Data experience to follow this tutorial?**
+No. The tutorial walks through creating the two required zones (SERP API and Web Unlocker) from scratch. The only prerequisite is a Bright Data account — a free trial is available.
+
+**Q: What happens if the agent can't find information about a company?**
+The agent degrades gracefully. For less-documented companies, Claude produces a thinner report with more approximate figures and more fallback searches. The "What to try next" section covers how to interpret these cases.
+
+**Q: How many tool calls does a typical research run make?**
+For a well-documented company like OpenAI, expect 14–16 tool calls across 6 searches and 8 scraped pages. For a newer startup with limited public information, the agent typically makes 8–10 calls before writing the report.
+
+**Q: Can I add more data sources beyond Google search and web scraping?**
+Yes. Any HTTP call can become a Claude tool. The "What to try next" section outlines how to add a LinkedIn scraper or a Crunchbase-specific tool by following the same pattern used for `search_web` and `scrape_url`.
 
 ## Conclusion
 

--- a/tutorials/en/claude-bright-data-research-agent/article.mdx
+++ b/tutorials/en/claude-bright-data-research-agent/article.mdx
@@ -1,0 +1,295 @@
+---
+title: "Build a Startup Research Agent with Claude API and Bright Data"
+description: "Learn how to build a fully programmatic startup research agent using Claude's tool use feature and Bright Data's SERP API and Web Unlocker. The agent searches the web, scrapes live pages, and produces a structured research report automatically."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-ui-overview/public"
+authorUsername: "stevekimoi"
+---
+
+## Introduction
+
+Every existing Bright Data tutorial that uses Claude does it the same way: open Claude Desktop, configure an MCP server, and chat with it. That approach is fine for exploration, but it is not something you can ship.
+
+This tutorial takes a different path. You will build a fully programmatic research agent using the **Claude API** directly, with Bright Data's **SERP API** and **Web Unlocker** wired in as tools. The result is a deployable Python application. Give it a company name and it returns a structured research report covering founders, funding, business model, and recent news — no browser, no chat UI, no manual steps.
+
+By the end you will have:
+- A working agent that drives itself through a tool-use loop
+- A live web interface that streams the agent's activity in real time
+- A clear understanding of how to wire any data source into Claude's tool system
+
+The full source code is on [GitHub](https://github.com/Stephen-Kimoi/claude-bright-data-research-agent).
+
+## Prerequisites
+
+- Python 3.10 or higher
+- An [Anthropic account](https://console.anthropic.com) with an API key
+- A [Bright Data account](https://brightdata.com) (free trial available)
+- Basic familiarity with Python and REST APIs
+
+## Step 1: Set up your Bright Data zones
+
+Bright Data organises its APIs into **zones** — named configurations you create in the dashboard. You need two: one for search, one for scraping.
+
+**Create the SERP API zone**
+
+Log into your Bright Data dashboard. On the left sidebar click **Web Access**, then **Create API**. Select **SERP API**, give it a name (this tutorial uses `serp_api2`), choose **Full JSON** as the default response format, and click **Add API**.
+
+**Create the Web Unlocker zone**
+
+Repeat the same flow: **Create API**, select **Web Unlocker API**, name it `web_unlocker1`, leave CAPTCHA Solver enabled, and click **Add API**.
+
+Once both zones are created, note your API key from the dashboard home page. It is the same key for both zones.
+
+## Step 2: Set up the project
+
+Clone the repository and create a virtual environment:
+
+```bash
+git clone https://github.com/Stephen-Kimoi/claude-bright-data-research-agent.git
+cd claude-bright-data-research-agent
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Create a `.env` file in the project root with your credentials:
+
+```
+ANTHROPIC_API_KEY=your_anthropic_api_key
+BRIGHT_DATA_API_KEY=your_bright_data_api_key
+SERP_ZONE=serp_api2
+UNLOCKER_ZONE=web_unlocker1
+```
+
+## Step 3: Understand the two Bright Data tools
+
+The agent has two tools it can call. Both hit the same Bright Data REST endpoint (`https://api.brightdata.com/request`) using your API key as a Bearer token. What changes is the `zone` and `url` in the request body.
+
+**`search_web` — SERP API**
+
+Sends a Google search URL to Bright Data. The response is a structured JSON object with `organic` results containing title, URL, and snippet for each result. No proxy setup, no headless browser — one HTTP call returns clean search data.
+
+```python
+def search_web(query: str) -> str:
+    search_url = f"https://www.google.com/search?q={requests.utils.quote(query)}&hl=en&gl=us"
+    payload = {"zone": SERP_ZONE, "url": search_url, "format": "json"}
+    resp = requests.post(BRIGHT_DATA_ENDPOINT, headers=BD_HEADERS, json=payload, timeout=30)
+    body = json.loads(resp.json()["body"])
+    organic = body.get("organic", [])
+    # format and return results...
+```
+
+**`scrape_url` — Web Unlocker**
+
+Sends any target URL to Bright Data. The Web Unlocker handles proxy rotation, CAPTCHA solving, and JavaScript rendering automatically. You receive the raw HTML back, which the function strips of tags before returning the text to Claude.
+
+```python
+def scrape_url(url: str) -> str:
+    payload = {"zone": UNLOCKER_ZONE, "url": url, "format": "raw"}
+    r = requests.post(BRIGHT_DATA_ENDPOINT, headers=BD_HEADERS, json=payload, timeout=45)
+    text = r.text
+    text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<[^>]+>", " ", text)
+    return re.sub(r"\s+", " ", text).strip()[:4000]
+```
+
+## Step 4: Wire the tools into Claude's tool-use loop
+
+This is the core of the agent. Claude's tool-use works as a loop: you send a message, Claude either returns a final answer or requests one or more tool calls, you execute the tools and send the results back, and the loop continues until Claude signals it is done.
+
+The tool definitions tell Claude what each tool does and what inputs to provide:
+
+```python
+TOOLS = [
+    {
+        "name": "search_web",
+        "description": "Search Google for information about a company. Use this to find funding details, founders, product descriptions, news, and more.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The search query"}
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "scrape_url",
+        "description": "Fetch the full content of a webpage. Use this to read a company's About page, Crunchbase profile, or any relevant URL found in search results.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "url": {"type": "string", "description": "The full URL to fetch"}
+            },
+            "required": ["url"],
+        },
+    },
+]
+```
+
+The agent loop:
+
+```python
+messages = [{"role": "user", "content": f"Research this startup: {company_name}"}]
+
+while True:
+    response = client.messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=4096,
+        system=SYSTEM_PROMPT,
+        tools=TOOLS,
+        messages=messages,
+    )
+
+    if response.stop_reason == "end_turn":
+        # Claude finished — the report is in response.content
+        return response
+
+    # Claude called tools — execute each one and return the results
+    tool_results = []
+    for block in response.content:
+        if block.type != "tool_use":
+            continue
+        if block.name == "search_web":
+            result = search_web(block.input["query"])
+        elif block.name == "scrape_url":
+            result = scrape_url(block.input["url"])
+        tool_results.append({
+            "type": "tool_result",
+            "tool_use_id": block.id,
+            "content": result,
+        })
+
+    messages.append({"role": "assistant", "content": response.content})
+    messages.append({"role": "user", "content": tool_results})
+    # loop continues
+```
+
+The key detail is `stop_reason`. When it equals `"tool_use"`, Claude is asking you to run tools. When it equals `"end_turn"`, it has finished and the final report is in the response. Everything else is just shuttling data back and forth.
+
+## Step 5: Run the agent from the terminal
+
+You can run the agent directly without the web UI:
+
+```bash
+python agent.py "OpenAI"
+```
+
+You will see live output as the agent works, with each tool call logged:
+
+```
+Researching: OpenAI
+==================================================
+[Tool: search_web] {"query": "OpenAI startup overview founding history"}
+[Result preview] Search results for 'OpenAI startup overview'...
+
+[Tool: search_web] {"query": "OpenAI founders and key team members"}
+[Result preview] Search results for 'OpenAI founders'...
+
+[Tool: scrape_url] {"url": "https://en.wikipedia.org/wiki/OpenAI"}
+[Result preview] OpenAI - Wikipedia...
+```
+
+## Step 6: Run the web UI
+
+The web interface makes the agent's behaviour visible and explainable. Start the Flask server:
+
+```bash
+python app.py
+```
+
+Open `http://localhost:5000`. You will see the landing page with a search input, a three-step "How it works" explanation, and six clickable example cards.
+
+![The landing page showing the search input, How it works section, and example company cards](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-landing-how/public)
+
+Below the How it works section, the examples grid shows six pre-loaded company cards. Click any card to immediately start researching that company.
+
+![The examples grid with six clickable company cards including Mistral AI, Cursor, ElevenLabs, Harvey AI, Udio, and Linear](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-landing-examples/public)
+
+## Step 7: Watch the agent work
+
+Type a company name (or click an example card) and click **Research**. The two-panel workspace opens immediately.
+
+The **Agent Activity** panel on the left streams every action the agent takes in real time. When you research "OpenAI", here is what you will see first: a thinking step where Claude announces its plan, followed by a burst of parallel Google searches.
+
+![The Agent Activity panel showing the initial thinking step followed by five simultaneous Google searches for OpenAI](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-activity-searches/public)
+
+Claude fires multiple searches in the first pass to cover different angles: company overview, founders, funding, business model, and recent news. These are all independent tool calls that happen within a single response from the API.
+
+After the initial searches return results, Claude decides which URLs look most useful and starts scraping them for full page content.
+
+![The activity panel showing Claude's thinking step followed by scraping of Wikipedia, Britannica, openai.com, and tracxn.com](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-activity-scraping/public)
+
+Watch how Claude narrates its own reasoning in the **Thinking** items. It explains why it is moving from search to scraping, what it expects to find, and when it has enough data to write the report.
+
+Claude continues scraping additional sources for recent news and financial data, then signals completion.
+
+![The final activity items showing scraping of observer.com, technologychecker.io, getlatka.com, and foundationinc.co, followed by a final thinking step and the green Complete indicator](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-activity-complete/public)
+
+The green **Complete** item at the bottom confirms the agent has finished. At the same time, the report panel on the right populates.
+
+## Step 8: Read the report
+
+The **Research Report** panel renders the full markdown report from Claude. For OpenAI, the agent produced a report with eight sections.
+
+The first thing that appears is the Company Overview table with factual fields pulled from live sources.
+
+![The report panel showing the Company Overview table for OpenAI with legal name, type, founding date, headquarters, revenue, and valuation](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-overview/public)
+
+Notice the data quality: `$730 billion (pre-money, Feb 2026 round)` and `~$13.1 billion` revenue came from pages the agent scraped during the run — not from Claude's training data. Bright Data's Web Unlocker retrieved that content at the time you made the request.
+
+Scrolling down, the Founders section shows a structured table with role and current status for each member of OpenAI's original 11-person founding team.
+
+![The report showing the beginning of the Founders section with a table of co-founders including Sam Altman, Elon Musk, Greg Brockman, and Ilya Sutskever](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-founders/public)
+
+The table continues with all 11 founding members:
+
+![The full founders table showing all 11 co-founders with their roles at founding and current status](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-founders-full/public)
+
+After the founding team, the report includes a Current Key Leadership table showing who is actually running the company today.
+
+![The leadership section showing the current key leadership table with Sam Altman as CEO and the full board of directors](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-leadership/public)
+
+The Funding History section shows all 13 rounds in chronological order, with amounts and lead investors.
+
+![The Funding History section showing OpenAI's funding rounds from the $130M seed in December 2015 through the $10B Series E with Microsoft and the $300M Series E with Sequoia and Andreessen Horowitz](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-report-funding/public)
+
+Here is what the full workspace looks like with both panels active simultaneously, showing 6 searches, 8 scraped pages, and 14 total tool calls for this research run:
+
+![The full two-panel workspace showing the Agent Activity feed on the left and the populated Research Report on the right, with the stats bar showing 6 searches, 8 pages scraped, and 14 tool calls](https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-workspace-full/public)
+
+## How the streaming works
+
+The web UI receives the agent's progress in real time via **Server-Sent Events (SSE)**. The Flask endpoint wraps the `run_agent_stream()` generator and converts each yielded event into a SSE `data:` line:
+
+```python
+@app.route("/research", methods=["POST"])
+def research():
+    company = request.json.get("company", "").strip()
+
+    def generate():
+        for event in run_agent_stream(company):
+            yield f"data: {json.dumps(event)}\n\n"
+        yield "data: {\"type\": \"done\"}\n\n"
+
+    return Response(stream_with_context(generate()), mimetype="text/event-stream")
+```
+
+The frontend uses `fetch` with a `ReadableStream` reader rather than `EventSource` because the endpoint uses POST. Each chunk is decoded, split on newlines, and parsed as JSON. The event `type` field controls what gets rendered — search queries go to the activity feed, the final `report` type populates the markdown panel.
+
+## What to try next
+
+**Research a newer, less-documented startup.** Try searching for Udio or Reflection AI. The agent will produce a thinner report with more approximate figures and more fallback searches. This is expected behaviour and useful to understand — the tool results are only as rich as the publicly available data.
+
+**Research a company with an ambiguous name.** Try "Linear" or "Hex". Watch how Claude disambiguates using search snippets before committing to scraping specific pages.
+
+**Add a third tool.** The pattern extends naturally. You could add a `search_linkedin` tool that calls Bright Data's LinkedIn scraper, or a `get_crunchbase` tool that hits a specific Crunchbase URL. Any HTTP call can become a tool.
+
+**Export the report.** The final report string is plain markdown. You can write it to a file, push it to Notion via their API, or parse it with another Claude call to extract structured fields like funding amounts into a database.
+
+## Conclusion
+
+The difference between this agent and a Claude Desktop MCP setup is that this one is a Python process you control. It has no GUI dependency, no chat session to manage, and no manual steps between input and output. You can call `run_agent("Stripe")` from any Python script, schedule it as a cron job, or wrap it in a REST API.
+
+That is what the Claude API's tool use system enables: Claude as an orchestration layer that decides which data to fetch and when, while you control the tools it calls. Bright Data handles the hard parts of live web access — proxy rotation, CAPTCHA solving, anti-bot bypass — so the agent can read any public page without infrastructure work on your end.
+
+The [Web Data UNLOCKED hackathon](https://lablab.ai/ai-hackathons/brightdata-ai-agents-web-data-hackathon) Track 1 asks builders to create agents that research and analyse companies using live web data. This project is a direct starting point for that track — clone the repo, swap in your credentials, and extend it with the data sources your use case needs.


### PR DESCRIPTION
## Summary

- Adds a new tutorial: *Build a Startup Research Agent for AI Hackathons with Claude API and Bright Data*
- Covers building a fully programmatic research agent using the Claude API tool-use loop with Bright Data's SERP API and Web Unlocker
- Includes a Flask + SSE web UI that streams tool calls in real time
- Companion GitHub repo: https://github.com/Stephen-Kimoi/claude-bright-data-research-agent

## What's in the tutorial

- Step-by-step setup of two Bright Data zones (SERP API + Web Unlocker)
- Full agent loop implementation with `search_web` and `scrape_url` tools
- Live streaming web UI (dark theme, activity feed, markdown report panel)
- 12 screenshots showing the agent researching OpenAI end-to-end
- FAQ section and "What to try next" extensions

## Test plan

- [ ] MDX renders without errors
- [ ] All images load (Cloudflare Images URLs)
- [ ] Code blocks have language declarations
- [ ] Internal links to `/event` and `/ai-hackathons/brightdata-ai-agents-web-data-hackathon` resolve
- [ ] No placeholder text or skeleton sections