### PR TITLE
Update content pipeline skills: prototype-ship, publish-check, content-start

### DIFF
--- a/.agents/skills/content-start/SKILL.md
+++ b/.agents/skills/content-start/SKILL.md
@@ -56,6 +56,18 @@ Present:
 
 Wait for user confirmation before proceeding to draft.
 
+### 5b. Build a working prototype (tutorials with code only)
+
+Before writing a single word of the tutorial article:
+
+1. Create the project directory under `/Users/la/lablab-ai/[slug]/`
+2. Build the full end-to-end implementation — all code must run without errors
+3. Verify the golden path works (real API calls, real output)
+4. Note any gotchas, non-obvious config steps, or error patterns encountered — these become the most valuable parts of the tutorial
+5. Only proceed to writing once the prototype works end-to-end
+
+This step is mandatory for all tutorials. Do not start drafting until the code is confirmed working.
+
 ### 6. Set Notion task to In Progress
 
 Update the Notion task status to `In Progress`.
@@ -69,6 +81,7 @@ Confirm the following are locked before writing begins:
 - [ ] Sources gathered
 - [ ] Notion task is `In Progress`
 - [ ] File location decided: `articles/[slug].md` or `tutorials/[slug]/article.md`
+- [ ] Working prototype built and verified at `/Users/la/lablab-ai/[slug]/` (tutorials only)
 
 ## Content type reminders
 

--- a/.agents/skills/prototype-ship/SKILL.md
+++ b/.agents/skills/prototype-ship/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: prototype-ship
+description: Build a working prototype, verify it end-to-end, create a GitHub repo, commit each file individually with a descriptive message, build a web UI frontend, and push everything. Use whenever a tutorial prototype is ready to be shipped to GitHub.
+compatibility: Designed for Claude Code. Requires gh CLI authenticated as Stephen-Kimoi.
+---
+
+## Steps
+
+### 1. Verify the prototype works end-to-end
+
+Before touching git:
+- Run the core script manually and confirm it produces real output
+- Fix any errors until a clean run completes
+- Note any gotchas encountered — these are tutorial gold
+
+### 2. Build a web UI (if not already present)
+
+Every prototype needs a UI that non-technical people can understand.
+
+**Required files:**
+- `agent.py` (or equivalent) — refactor to expose a **generator/stream interface** alongside the CLI interface. The generator yields typed event dicts: `{"type": "tool_call"|"tool_result"|"thinking"|"report"|"error", ...}`
+- `app.py` — Flask server with a **Server-Sent Events (SSE) endpoint** that wraps the generator
+- `templates/index.html` — single-page UI with:
+  - Input field + submit button
+  - Live **activity feed** panel (shows tool calls streaming in real time)
+  - **Output/report panel** (renders markdown with marked.js or similar)
+  - Stats bar (counts of tool calls, searches, scrapes, etc.)
+- `requirements.txt` — must include `flask>=3.0.0`
+
+**UI design standards:**
+- Dark theme (`#0f0f13` background)
+- Accent color: `#7c6aff` (purple) for primary actions, `#06b6d4` (cyan) for secondary
+- Animated dot indicator while agent is running
+- Activity items animate in with `slideIn` keyframe
+- Markdown rendered in the report panel — use `marked.js` from CDN
+- No frontend framework — vanilla JS only
+
+**Smoke test the UI before committing:**
+```bash
+source venv/bin/activate && python app.py &
+sleep 2 && curl -s http://localhost:5000 | head -3
+kill %1
+```
+
+### 3. Create the GitHub repository
+
+```bash
+gh repo create Stephen-Kimoi/<repo-slug> \
+  --public \
+  --description "<one-line description>"
+```
+
+Then:
+```bash
+git init
+git config user.name "Steve Kimoi"
+git config user.email "stephen.kimoi@nativelyai.com"
+git remote add origin https://github.com/Stephen-Kimoi/<repo-slug>.git
+git branch -M main
+```
+
+### 4. Commit each file individually
+
+Commit in this order, one file per commit:
+
+| File | Commit message pattern |
+|---|---|
+| `.gitignore` | `Add .gitignore` + what it excludes |
+| `requirements.txt` | `Add requirements.txt` + list the key deps and why |
+| Core logic file (e.g. `agent.py`) | `Add <file> — <one-line role>` + what it implements and how |
+| Server file (e.g. `app.py`) | `Add <file> — <one-line role>` + what the endpoint does |
+| `templates/index.html` | `Add templates/index.html — frontend UI` + what it shows |
+| `README.md` | `Add README.md` + what it covers |
+
+**Commit message rules:**
+- Subject line: `Add <filename> — <role>` (imperative, under 72 chars)
+- Body: 2–4 lines explaining what the file does and any non-obvious decisions
+- No `Co-Authored-By` lines
+- No "Generated with Claude" footers
+
+### 5. Write the README
+
+The README must include:
+- [ ] What the project does (2–3 sentences)
+- [ ] Architecture diagram (ASCII, showing data flow)
+- [ ] Project file structure with one-line descriptions
+- [ ] Prerequisites (accounts, tools needed)
+- [ ] Full setup steps (clone → venv → pip install → .env → run)
+- [ ] How the core loop works (simplified code snippet)
+- [ ] Example output
+- [ ] Ideas for extending the project
+- [ ] Built-with table
+
+### 6. Push
+
+```bash
+git push -u origin main
+```
+
+### 7. Hand off
+
+Confirm:
+- [ ] Prototype runs end-to-end without errors
+- [ ] UI serves at `localhost:5000` and streams live tool calls
+- [ ] All files committed individually with descriptive messages
+- [ ] README covers architecture + full setup
+- [ ] Repo is public at `https://github.com/Stephen-Kimoi/<repo-slug>`
+- [ ] Ready to write the tutorial (proceed to drafting)

--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -26,6 +26,7 @@ Read the full draft file.
 - [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: use the Cloudflare Images API with the `CLOUDFLARE_IMAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from `.agents/skills/.env`.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
+- [ ] **No em dashes** — scan the full body for `—` and replace with commas, colons, periods, or parentheses. This is a hard rule that applies to every piece.
 
 #### For articles only:
 
@@ -44,7 +45,8 @@ Read the full draft file.
 - [ ] **Prerequisites section present** — tools, API keys, framework versions listed
 - [ ] **`.env` format shown** (if needed) — with placeholder values, never real keys
 - [ ] **Final output shown** — screenshot, terminal output, or demo of the working result
-- [ ] **File saved in** `tutorials/[slug]/article.md`
+- [ ] **File saved as** `tutorials/en/[slug].mdx` — a single flat file, never a folder with `article.mdx` inside
+- [ ] **GitHub line references on all code excerpts** — every code block that references a project file must include a link like `Full implementation in [\`agent.py\`, lines 74-97](https://github.com/...#L74-L97):` immediately before the block. Do not use `# from file.py` comments as a substitute.
 
 ### 4. Report results
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is the Lablab community-content repo. It contains all published articles, t
 
 ```
 blog/en/          — Articles (MDX)
-tutorials/        — Tutorial articles (MDX)
+tutorials/en/     — Tutorial articles (MDX) — single flat files: tutorials/en/[slug].mdx (never a folder)
 technologies/     — Technology index pages
 topics/           — Topic index pages
 ```
@@ -17,6 +17,7 @@ topics/           — Topic index pages
 
 - **Frontmatter required on every file:** `title`, `description`, `image`, `authorUsername`
 - **Images must use Cloudflare Images:** all image URLs must be `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no hotlinked external images, no Cloudinary URLs
+- **No em dashes in body text:** replace `—` with commas, colons, periods, or parentheses throughout
 - **Cloudflare Images account hash:** `K11gkZF3xaVyYzFESMdWIQ` (API token in `.agents/skills/.env` as `CLOUDFLARE_IMAGES_TOKEN`)
 - **Author username:** `stevekimoi`
 - **SEO guidelines:** see `SEO_GUIDELINES.md` for keyword strategy and frontmatter formatting rules
@@ -33,6 +34,7 @@ Five agent skills live in `.agents/skills/` and cover the full content lifecycle
 | [`publish-check`](.agents/skills/publish-check/SKILL.md) | When a draft is complete — runs the full publishing checklist and updates Notion to Done |
 | [`seo-apply`](.agents/skills/seo-apply/SKILL.md) | After a draft passes publish-check — reads this week's Notion SEO clusters and applies surgical keyword improvements without changing tone |
 | [`weekly-ai-recap`](.agents/skills/weekly-ai-recap/SKILL.md) | Every Monday — researches the week's top AI news, writes the recap article, produces the social post brief |
+| [`prototype-ship`](.agents/skills/prototype-ship/SKILL.md) | After a working prototype is built — adds a web UI frontend, commits each file individually with descriptive messages, creates the GitHub repo, and pushes |
 
 ## Notion
 


### PR DESCRIPTION
## Summary

- Add `prototype-ship` skill: covers building a web UI, committing each file individually with descriptive messages, creating a GitHub repo as Stephen-Kimoi, and pushing. Used after a working prototype is built.
- Update `content-start` skill: add mandatory prototype-first step for code tutorials — build and verify working code before writing.
- Update `publish-check` skill: add three missing checks — no em dashes, GitHub line references on code excerpts, flat `.mdx` file path rule.
- Update `CLAUDE.md`: clarify tutorial file naming convention (`tutorials/en/[slug].mdx`, never a folder) and add no-em-dashes rule.

## Test plan

- [ ] Skill files render correctly in the `.agents/skills/` directory
- [ ] CLAUDE.md changes are accurate and consistent with repo convention