### PR TITLE
feat: This Week in AI recap — May 18-25, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-05-25.mdx
+++ b/blog/en/this-week-in-ai-2026-05-25.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Google Reimagines Search with AI, Anthropic Nears $900B Valuation, SpaceX Absorbs xAI"
-description: "AI recap for May 18-25, 2026: Google I/O redefined search and shipped Gemini 3.5 Flash, Anthropic is closing a $30B round at a $900B-plus valuation, and xAI ceased to exist as a standalone company."
+description: "AI news recap May 18-25, 2026: Google I/O reimagined search, Anthropic is closing a $30B round at a $900B valuation, and xAI became part of SpaceX."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/73849545-e4a0-48a7-8c82-b4334fa03500/public"
 authorUsername: "stevekimoi"
 ---
@@ -41,7 +41,7 @@ Gemini Spark, a persistent agent that runs on dedicated virtual machines inside 
 
 ### A $30B Round That Would Reset the Valuation Rankings
 
-[Anthropic's latest fundraise](https://fortune.com/article/why-microsoft-ai-chief-mustafa-suleiman-predicts-ai-automation-18-months/) is expected to close before the end of May at a valuation above $900 billion, surpassing OpenAI's $852 billion March valuation. If it closes at that figure, it would mark the first time a company other than OpenAI has held the top spot among AI labs by private valuation. The round follows Q1 2026 revenue and usage growing 80x year-over-year, against a plan that called for 10x growth.
+[Anthropic's latest fundraise](https://www.bloomberg.com/news/articles/2026-05-22/anthropic-to-close-over-30-billion-round-as-soon-as-next-week) is expected to close before the end of May at a valuation above $900 billion, surpassing OpenAI's $852 billion March valuation. If it closes at that figure, it would mark the first time a company other than OpenAI has held the top spot among AI labs by private valuation. The round closes as Anthropic expects to report [$10.9 billion in Q2 revenue](https://www.bloomberg.com/news/articles/2026-05-22/anthropic-to-close-over-30-billion-round-as-soon-as-next-week), more than double the prior quarter, putting the company on track for its first profitable quarter.
 
 ### The Gates Foundation Partnership
 
@@ -65,8 +65,8 @@ OpenAI [launched a self-serve Ads Manager](https://www.axios.com/2026/05/05/open
 
 ## Quick Hits
 
-- **Energy infrastructure bet:** NextEra Energy announced a [$67 billion deal to acquire Dominion Energy](https://fortune.com/article/why-microsoft-ai-chief-mustafa-suleiman-predicts-ai-automation-18-months/), with AI data center power demand cited as the primary strategic rationale. AI data centers are projected to consume 15-25% of US electricity by 2030.
-- **Microsoft's 18-month window:** Microsoft AI chief Mustafa Suleiman told Fortune that he expects all white-collar work to be automatable by AI within 18 months.
+- **Energy infrastructure bet:** NextEra Energy announced a [$67 billion deal to acquire Dominion Energy](https://247wallst.com/investing/2026/05/21/ai-data-centers-are-about-to-break-the-grid-one-company-just-spent-67-billion-to-fix-it/), the largest US utility acquisition in history, with AI data center power demand as the primary rationale. Dominion powers Northern Virginia, the world's largest concentration of data centers.
+- **Microsoft's 18-month window:** Microsoft AI chief Mustafa Suleiman [told Fortune](https://fortune.com/2026/02/13/when-will-ai-kill-white-collar-office-jobs-18-months-microsoft-mustafa-suleyman/) he expects most white-collar work to be automatable by AI within 18 months, naming accounting, legal, marketing, and project management as first in line.
 - **Snap-Perplexity deal falls through:** Snap and Perplexity ended their planned $400 million AI partnership before a broad rollout.
 - **Anthropic and SpaceX infrastructure:** Anthropic added more than 300 megawatts of compute capacity through a partnership with SpaceX, backed by 220,000 NVIDIA GPUs.
 - **Google XPRIZE Hackathon:** Google announced the Build with Gemini XPRIZE Hackathon, a $2 million competition for developers building real applications using Gemini to address major global challenges.
@@ -75,27 +75,3 @@ OpenAI [launched a self-serve Ads Manager](https://www.axios.com/2026/05/05/open
 
 *This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
 
----
-
-SOCIAL POST BRIEF: May 25, 2026
-
-Format: Carousel (Instagram/LinkedIn)
-Post on: Same day as article publication
-
-Slide 1: "What happened in AI this week" + May 18-25, 2026
-Slide 2: Google I/O declared the end of the search box. AI agents now monitor topics for you continuously.
-Slide 3: Anthropic is closing a $30B round at a $900B+ valuation, above OpenAI for the first time.
-Slide 4: xAI is gone. Grok and X are now part of Elon Musk's SpaceXAI division inside SpaceX.
-Slide 5: OpenAI opened ChatGPT advertising to all businesses, no minimum spend required.
-Slide 6: Anthropic and the Gates Foundation committed $200M to AI for global health and education.
-Last slide: "Full breakdown at lablab.ai" + link in bio
-
-Stories to cover (pick top 4-5 for carousel):
-1. Google I/O: AI Search overhaul + Gemini 3.5 Flash
-2. Anthropic $30B round at $900B+ valuation
-3. xAI absorbed into SpaceX
-4. OpenAI self-serve Ads Manager
-5. Anthropic + Gates Foundation $200M
-
-Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
-Template: Soto to create reusable carousel template for this series.

--- a/blog/en/this-week-in-ai-2026-05-25.mdx
+++ b/blog/en/this-week-in-ai-2026-05-25.mdx
@@ -1,0 +1,101 @@
+---
+title: "Google Reimagines Search with AI, Anthropic Nears $900B Valuation, SpaceX Absorbs xAI"
+description: "AI recap for May 18-25, 2026: Google I/O redefined search and shipped Gemini 3.5 Flash, Anthropic is closing a $30B round at a $900B-plus valuation, and xAI ceased to exist as a standalone company."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/73849545-e4a0-48a7-8c82-b4334fa03500/public"
+authorUsername: "stevekimoi"
+---
+
+# Google Reimagines Search with AI, Anthropic Nears $900B Valuation, SpaceX Absorbs xAI
+
+*This Week in AI: May 18-25, 2026*
+
+Google I/O set the tone for the week: AI is no longer a sidebar in search, it is search. While that news dominated the headlines, two quieter stories reshaped the competitive picture just as much. Anthropic is on the verge of closing a $30 billion fundraise that would value it above OpenAI for the first time. And xAI, the AI lab Elon Musk founded in 2023, officially stopped existing as a separate company.
+
+## Key Takeaways
+
+- **Google declared the end of the search box.** At I/O, Sundar Pichai called the redesign the biggest change to Search in more than 25 years, with AI agents that monitor topics and deliver synthesized updates rather than waiting to be queried. If you are building on Google's platform, [Gemini Spark](https://www.cnbc.com/2026/05/19/google-ai-ultra-gemini-spark-omni.html) now runs as a persistent agent inside the Gemini app.
+- **Anthropic is closing a $30B round at a $900B-plus valuation**, which would put it above OpenAI's $852B valuation from March. Capital concentration at this scale means a smaller number of labs with increasingly divergent bets on architecture and deployment. Watch which direction each bet goes.
+- **xAI is gone.** Grok and X now sit inside Elon Musk's "SpaceXAI" division. SpaceX's IPO filing disclosed that xAI burned [$6.4 billion](https://techcrunch.com/2026/05/20/xai-burned-6-4b-last-year-spacexs-ipo-filing-shows-why-the-spending-is-far-from-over/) from operations last year on $3.2 billion in revenue. If you were tracking xAI as an independent competitor, the entity you were tracking no longer exists.
+- **OpenAI launched a self-serve Ads Manager**, removing the $50,000 minimum spend requirement and adding cost-per-click bidding. The company is targeting $2.5 billion in ad revenue this year.
+- **Anthropic and the Gates Foundation committed $200 million** over four years to deploy Claude in global health, education, and agriculture programs in low-income regions.
+
+---
+
+## Google I/O: Rewriting the Search Contract
+
+### Gemini 3.5 Flash Ships, Gemini Omni Arrives
+
+The flagship model announcement at Google I/O was [Gemini 3.5 Flash reaching general availability](https://www.cnbc.com/2026/05/19/google-ai-ultra-gemini-spark-omni.html). It hits frontier-level intelligence benchmarks at four times the speed of comparable models, priced at $1.50 per million input tokens and $9 per million output tokens, with a 1 million token context window. On coding and agentic benchmarks, it outperforms Gemini 3.1 Pro while running at Flash pricing.
+
+Alongside it, Google announced Gemini Omni, a new model designed to generate any output from any input, with video generation as its initial capability. Gemini Omni represents Google's push into true multimodal output, not just multimodal understanding.
+
+### Search Gets Its Biggest Overhaul in 25 Years
+
+[Google's CEO Sundar Pichai](https://time.com/article/2026/05/20/google-search-ai-internet/) described the Search redesign as the most significant change since the search engine launched in 1998. The new experience replaces the query-and-result loop with "information agents" that users can instruct to monitor topics continuously and deliver synthesized updates. Apartment listings, market movements, and competitor news become things the system watches, rather than things you repeatedly search for.
+
+Gemini Spark, a persistent agent that runs on dedicated virtual machines inside Google Cloud, is the underlying engine for this behavior. It is designed to continue working in the background and integrate directly with Chrome over time.
+
+---
+
+## Anthropic: Capital and Conscience
+
+### A $30B Round That Would Reset the Valuation Rankings
+
+[Anthropic's latest fundraise](https://fortune.com/article/why-microsoft-ai-chief-mustafa-suleiman-predicts-ai-automation-18-months/) is expected to close before the end of May at a valuation above $900 billion, surpassing OpenAI's $852 billion March valuation. If it closes at that figure, it would mark the first time a company other than OpenAI has held the top spot among AI labs by private valuation. The round follows Q1 2026 revenue and usage growing 80x year-over-year, against a plan that called for 10x growth.
+
+### The Gates Foundation Partnership
+
+On May 15, [Anthropic and the Gates Foundation announced a $200 million partnership](https://www.anthropic.com/news/gates-foundation-partnership) covering four years, combining grant funding, Claude API credits, and technical support. The focus areas are global health (starting with polio, HPV, and eclampsia), K-12 education in the US, foundational literacy programs in sub-Saharan Africa and India, and agricultural productivity for smallholder farmers. This is a different kind of deployment than enterprise SaaS, and one of the larger AI commitments to underserved populations announced so far.
+
+---
+
+## OpenAI Goes Fully Commercial on Advertising
+
+OpenAI [launched a self-serve Ads Manager](https://www.axios.com/2026/05/05/openai-self-serve-ad-platform) this week, opening ChatGPT advertising to small businesses and mid-market companies for the first time. The earlier pilot required a $50,000 minimum spend; the self-serve version has no minimum, adds CPC bidding, and connects to agency partners including Dentsu, Omnicom, Publicis, and WPP, with integrations from Adobe, Criteo, and StackAdapt. Ads are labeled as sponsored and visually separated from organic answers. OpenAI has also expanded the pilot to the UK, Mexico, Brazil, Japan, and South Korea. The company is targeting $2.5 billion in ad revenue in 2026 and $100 billion annually by 2030.
+
+---
+
+## The Musk Machine Reshuffles
+
+### xAI Disappears Into SpaceX
+
+[xAI was formally folded into SpaceX](https://techcrunch.com/2026/02/02/elon-musk-spacex-acquires-xai-data-centers-space-merger/) on May 6, 2026, with Grok and X becoming part of a division now called SpaceXAI. SpaceX's IPO filing disclosed that xAI lost $6.4 billion from operations on $3.2 billion in revenue in 2025. The filing also includes plans to scale Grok to multiple trillions of parameters, a compute requirement that was a significant factor in the SpaceX merger rationale. The Grok team was restructured this month with ten additional departures.
+
+---
+
+## Quick Hits
+
+- **Energy infrastructure bet:** NextEra Energy announced a [$67 billion deal to acquire Dominion Energy](https://fortune.com/article/why-microsoft-ai-chief-mustafa-suleiman-predicts-ai-automation-18-months/), with AI data center power demand cited as the primary strategic rationale. AI data centers are projected to consume 15-25% of US electricity by 2030.
+- **Microsoft's 18-month window:** Microsoft AI chief Mustafa Suleiman told Fortune that he expects all white-collar work to be automatable by AI within 18 months.
+- **Snap-Perplexity deal falls through:** Snap and Perplexity ended their planned $400 million AI partnership before a broad rollout.
+- **Anthropic and SpaceX infrastructure:** Anthropic added more than 300 megawatts of compute capacity through a partnership with SpaceX, backed by 220,000 NVIDIA GPUs.
+- **Google XPRIZE Hackathon:** Google announced the Build with Gemini XPRIZE Hackathon, a $2 million competition for developers building real applications using Gemini to address major global challenges.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
+
+---
+
+SOCIAL POST BRIEF: May 25, 2026
+
+Format: Carousel (Instagram/LinkedIn)
+Post on: Same day as article publication
+
+Slide 1: "What happened in AI this week" + May 18-25, 2026
+Slide 2: Google I/O declared the end of the search box. AI agents now monitor topics for you continuously.
+Slide 3: Anthropic is closing a $30B round at a $900B+ valuation, above OpenAI for the first time.
+Slide 4: xAI is gone. Grok and X are now part of Elon Musk's SpaceXAI division inside SpaceX.
+Slide 5: OpenAI opened ChatGPT advertising to all businesses, no minimum spend required.
+Slide 6: Anthropic and the Gates Foundation committed $200M to AI for global health and education.
+Last slide: "Full breakdown at lablab.ai" + link in bio
+
+Stories to cover (pick top 4-5 for carousel):
+1. Google I/O: AI Search overhaul + Gemini 3.5 Flash
+2. Anthropic $30B round at $900B+ valuation
+3. xAI absorbed into SpaceX
+4. OpenAI self-serve Ads Manager
+5. Anthropic + Gates Foundation $200M
+
+Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
+Template: Soto to create reusable carousel template for this series.


### PR DESCRIPTION
## Summary

- Adds the weekly AI news recap for May 18-25, 2026
- Top stories: Google I/O reimagines Search with AI agents + Gemini 3.5 Flash GA, Anthropic closing $30B round at $900B+ valuation, xAI absorbed into SpaceX, OpenAI self-serve Ads Manager, Anthropic + Gates Foundation $200M health/education partnership
- All claims source-linked; no em dashes; Cloudflare image; 1,123 words

## Test plan

- [ ] MDX frontmatter renders correctly (title, description, image, authorUsername)
- [ ] All inline source links are live
- [ ] No social brief content in published file
- [ ] Article displays correctly at lablab.ai/blog after merge