### PR TITLE
Add Cognee technology page

### DIFF
--- a/technologies/cognee/index.mdx
+++ b/technologies/cognee/index.mdx
@@ -1,0 +1,74 @@
+---
+title: "Cognee"
+description: "Cognee is an open-source AI memory engine that builds knowledge graphs from your data, giving AI agents the ability to recall, connect, and reason with context across workflows."
+---
+
+# Cognee
+
+Cognee is an open-source AI memory engine built by Topoteretes UG, founded in 2024 by Vasilije Markovic and Boris Arzentar. The project started as an open-source initiative and has grown into a production-grade framework adopted by over 70 organizations, running more than one million pipelines per month. Cognee gives AI agents a shared, continuously improving memory by combining graph traversal and vector similarity into a single retrieval layer that goes well beyond standard RAG.
+
+| General | |
+|---------|--|
+| **Company** | [Cognee](https://www.cognee.ai/) |
+| **Founded** | 2024 by Vasilije Markovic and Boris Arzentar |
+| **Headquarters** | Berlin, Germany |
+| **Website** | [cognee.ai](https://www.cognee.ai/) |
+| **Documentation** | [docs.cognee.ai](https://docs.cognee.ai/getting-started/introduction) |
+| **GitHub** | [topoteretes/cognee](https://github.com/topoteretes/cognee) |
+| **Type** | AI Infrastructure, Memory Engine |
+
+---
+
+## Core Products
+
+### Cognee Memory Engine
+
+Cognee ingests data in any format and builds a structured knowledge graph with embeddings, making it queryable through four operations: remember, recall, forget, and improve. The default retrieval mode (GRAPH_COMPLETION) uses vector search as a hint to locate relevant graph triplets, then traverses the graph to assemble structured context before generating an answer. Memory graphs can be scoped per user, per group, or as a shared public graph, giving teams fine-grained multi-tenancy control.
+
+### Cognee UI
+
+Starting with v0.3.3, Cognee ships a local web interface with interactive notebooks and a Graph Explorer. Developers can run cognee methods, build pipelines, and visualize query results directly in the browser without leaving their local environment.
+
+---
+
+## Developer Resources
+
+Cognee provides a Python SDK that wraps the full memory pipeline in three core operations: `.add()` to ingest data, `.cognify()` to build the knowledge graph, and `.search()` to retrieve context. The SDK supports text files, structured datasets, and custom data formats.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.cognee.ai/getting-started/introduction): getting started guide, API reference, and examples
+- [GitHub](https://github.com/topoteretes/cognee): source code, issues, and community contributions
+- [PyPI](https://pypi.org/project/cognee/): install via `pip install cognee`
+- [LangChain integration](https://github.com/topoteretes/langchain-cognee): drop-in integration for LangChain projects
+
+---
+
+## Key Features
+
+**Unified three-layer storage**
+Cognee combines a graph store (Kuzu by default, also supports Neo4j, FalkorDB, Amazon Neptune, Memgraph), a vector store (LanceDB by default, also supports Qdrant, pgvector, Redis, Pinecone, ChromaDB), and a relational store (SQLite by default, also supports PostgreSQL) into a single memory interface.
+
+**14 retrieval modes**
+The framework ships with 14 configurable retrieval strategies. GRAPH_COMPLETION is the default and produces more structured, relationship-aware context than cosine-similarity chunk retrieval.
+
+**Automatic ontology management**
+Cognee continuously updates ontologies as new data is ingested, so the knowledge graph stays current without manual schema maintenance.
+
+**Multi-tenancy and graph isolation**
+Memory graphs can be instantiated per user, per group, or as shared public graphs, making it suitable for multi-user agent applications.
+
+---
+
+## Use Cases
+
+**Agentic workflows with persistent memory**
+Teams building AI agents that need to recall previous decisions, user preferences, or domain knowledge across sessions use Cognee to maintain a durable, queryable memory layer.
+
+**GraphRAG over private data**
+Organizations with large internal document libraries (legal, medical, research) use Cognee to transform document collections into navigable knowledge graphs, improving retrieval accuracy over standard vector search.
+
+**Multi-agent coordination**
+Shared graph instances let multiple agents read and write to the same memory space, enabling coordination without duplicating context across agent boundaries.


### PR DESCRIPTION
## Summary

- Adds `technologies/cognee/index.mdx` for [Cognee](https://www.cognee.ai/), an open-source AI memory engine for AI agents
- Covers company background (founded 2024, Berlin), core products, three-layer storage architecture, retrieval modes, and ecosystem integrations (LangChain, LlamaIndex, Qdrant)
- No subpages needed: Cognee has one core product with no distinct versioned models to split out

## Test plan

- [ ] Frontmatter has `title` and `description`
- [ ] `<TechTutorials/>` present in Developer Resources section
- [ ] No em dashes, no placeholder text, no marketing language
- [ ] All URLs point to live pages (cognee.ai, docs.cognee.ai, github.com/topoteretes/cognee)