### PR TITLE
Add TriggerWare technology page

### DIFF
--- a/technologies/triggerware/index.mdx
+++ b/technologies/triggerware/index.mdx
@@ -1,0 +1,86 @@
+---
+title: "TriggerWare"
+description: "TriggerWare by CalQLogic is a patented real-time analytics and automation platform that lets developers and business users query live data, set alerts, and trigger AI agent workflows without traditional ETL pipelines."
+---
+
+# TriggerWare
+
+TriggerWare is a cloud-based analytics and automation platform built by CalQLogic, a Los Angeles-based software company. The platform addresses a persistent gap in business intelligence: accessing truly live data from multiple sources and acting on it instantly, without expensive ETL/ELT pipelines or data syncing. TriggerWare is designed to serve both technical developers and non-technical business users, offering SQL-based APIs alongside no-code, natural language interfaces.
+
+| General | |
+|---------|--|
+| **Company** | [CalQLogic](https://www.calqlogic.com) |
+| **Founded** | 2017 |
+| **Headquarters** | Los Angeles, CA, USA |
+| **Website** | [triggerware.ai](https://triggerware.ai) |
+| **Documentation** | [docs.triggerware.com](https://docs.triggerware.com) |
+| **Console** | [console.triggerware.com](https://console.triggerware.com) |
+| **Type** | Real-Time Data Platform, AI Agent Infrastructure |
+
+---
+
+## Core Products
+
+### TriggerWare Platform
+
+The TriggerWare platform connects to internal and external data sources, correlates data across those sources in real time, and converts insights into alerts and AI agent triggers. It is delivered as a web app with REST API access and includes a console for building and managing data workflows. Each user gets a separate server instance, ensuring isolation and customizability.
+
+### MCP Integration for Agentic AI
+
+TriggerWare provides an MCP (Model Context Protocol) Server and Client that AI agents can use to pull real-time data on demand or to trigger agent actions when data conditions change. This makes TriggerWare a live data layer for autonomous AI workflows.
+
+### DELT (Dynamic Extract Load Transform)
+
+DELT is TriggerWare's patented approach to data retrieval that reads directly from source systems without staging data in a warehouse. This eliminates the latency and cost associated with conventional ETL/ELT pipelines while keeping query results current.
+
+---
+
+## Developer Resources
+
+TriggerWare is accessible via REST APIs for developers who prefer programmatic integration, and via a no-code console for business users. The platform supports MCP for agent tooling and offers SQL-compatible query access under the SQL Over Everything® API.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.triggerware.com) (official API and platform reference)
+- [Console / Free Trial](https://console.triggerware.com) (start building with a free trial)
+- [CalQLogic website](https://www.calqlogic.com) (company background and enterprise information)
+
+---
+
+## Key Features
+
+**Dynamic Extract Load Transform (DELT)**
+Retrieves data directly from source systems in real time, removing the need for ETL/ELT pipelines or data syncing that introduce lag and cost.
+
+**SQL Over Everything**
+A patented API layer that lets developers with SQL knowledge query any connected data source using familiar syntax, regardless of the underlying data format.
+
+**No-Code GenAI Connectors**
+Uses generative AI to create data connectors from natural language descriptions, so non-technical users can onboard new data sources without writing code.
+
+**Natural Language Query Engine**
+Allows business users to formulate queries by describing what they want in plain language, with results appearing immediately based on current data.
+
+**Real-Time Alerts**
+Sends notifications whenever query answers change, keeping decisions based on the most recent state of the data rather than a snapshot.
+
+**MCP Server and Client**
+Provides MCP-compatible tooling so AI agents can access live data or trigger workflows as part of autonomous decision loops.
+
+---
+
+## Use Cases
+
+**AI Agent Data Layer**
+Teams building autonomous AI agents can connect TriggerWare via MCP to give agents access to live business data, enabling decisions grounded in real-time context rather than static training data.
+
+**Business Monitoring and Alerts**
+Analysts and operations teams can set up queries on external and internal data sources and receive alerts when conditions change, such as market signals aligning with sales targets or supplier risk indicators shifting.
+
+**Real-Time Application Integration**
+Developers can embed live data queries into business applications using the SQL Over Everything API, removing the need to build and maintain separate data pipelines for each application.
+
+**IoT and Event Analytics**
+The platform supports time-stamped and IoT sensor data, making it suitable for use cases that involve monitoring physical systems or high-frequency event streams.


### PR DESCRIPTION
## Summary

- Adds `technologies/triggerware/index.mdx` for [TriggerWare](https://triggerware.ai/), a real-time data platform by CalQLogic (founded 2017, Los Angeles)
- Covers core products (DELT pipeline, MCP integration, SQL Over Everything API), key features, and use cases for AI builders
- No subpages needed: TriggerWare is one unified platform with no distinct versioned models to split out

## Test plan

- [ ] Frontmatter has `title` and `description`
- [ ] `<TechTutorials/>` present in Developer Resources section
- [ ] No em dashes, no placeholder text, no marketing language
- [ ] URLs verified: triggerware.ai, docs.triggerware.com, console.triggerware.com, calqlogic.com