### PR TITLE
Add demo video to Claude + Bright Data research agent tutorial

### DIFF
--- a/tutorials/en/claude-bright-data-research-agent-for-ai-hackathons.mdx
+++ b/tutorials/en/claude-bright-data-research-agent-for-ai-hackathons.mdx
@@ -5,6 +5,10 @@ image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/bright-data-tutorial-co
 authorUsername: "stevekimoi"
 ---
 
+## Demo
+
+<LiteYouTube videoId="3TwX4WLkk0s" containerClassName={"youtubeContainer"} />
+
 ## Introduction
 
 Type a company name. In under two minutes you have a structured research report: founders, funding history, business model, and this week's news, every data point fetched from live web sources at the moment you ask.


### PR DESCRIPTION
## Summary
- Adds a `## Demo` section with an embedded YouTube video (`3TwX4WLkk0s`) at the top of the Claude + Bright Data research agent tutorial
- Uses the standard `LiteYouTube` component pattern consistent with other tutorials in the repo

## Test plan
- [ ] Verify the `LiteYouTube` embed renders correctly on the tutorial page
- [ ] Confirm the Demo section appears above the Introduction section