### PR TITLE
Add This Week in AI recap — May 26 to June 2, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-06-02.mdx
+++ b/blog/en/this-week-in-ai-2026-06-02.mdx
@@ -1,0 +1,94 @@
+---
+title: "Anthropic Raises $65B at Near-$1T Valuation, Opus 4.8 Ships, OpenAI Proposes Pre-Release Regulator Testing"
+description: "AI news recap June 2026: Anthropic closed a $65 billion Series H at a $965 billion valuation, Claude Opus 4.8 launched, and OpenAI agreed to give governments early model access before public release."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/73849545-e4a0-48a7-8c82-b4334fa03500/public"
+authorUsername: "stevekimoi"
+---
+
+# Anthropic Raises $65B at Near-$1T Valuation, Opus 4.8 Ships, OpenAI Proposes Pre-Release Regulator Testing
+
+*This Week in AI: May 26 to June 2, 2026*
+
+This week belongs to Anthropic. A $65 billion funding round closing at a $965 billion valuation, a new flagship model, a path to its first quarterly profit, and Andrej Karpathy joining to lead pretraining research: four major developments in one week from a company that was primarily a research lab two years ago. Meanwhile, OpenAI proposed handing governments early model access before public release, and Intuit joined the AI restructuring wave by cutting 17% of its workforce.
+
+## Key Takeaways
+
+- **Anthropic:** Raised $65B at a $965B valuation, [topping OpenAI](https://www.cnbc.com/2026/05/28/anthropic-open-ai-startup-value.html) as the most valuable private AI company. If you are building on Claude, the funding signals significant compute expansion ahead.
+- **Claude Opus 4.8:** Anthropic's new flagship model shipped the same day as the funding announcement. Worth evaluating now if you are running production workloads on Opus 4.7 or earlier.
+- **OpenAI Frontier Governance:** OpenAI, xAI, and Microsoft agreed to give regulators early model access before public release. Expect new compliance checkboxes in enterprise vendor evaluations as governments build out testing capacity.
+- **Intuit cuts 17%:** 3,000 jobs cut as enterprise software companies continue replacing coordination roles with AI tooling. The pattern is now consistent enough to plan around.
+- **Karpathy joins Anthropic:** The most widely followed AI educator joins to rebuild pretraining research. What surfaces from that team over the next 12 to 18 months will matter.
+
+---
+
+## Anthropic's Defining Week
+
+### $65 Billion at a $965 Billion Valuation
+
+Anthropic [closed a $65 billion Series H on May 28](https://www.anthropic.com/news/series-h), led by Altimeter Capital, Dragoneer, Greenoaks, and Sequoia, with co-investors including Amazon ($5B committed), GIC, Blackstone, Fidelity, and Temasek. The round values Anthropic at $965 billion post-money, putting it ahead of OpenAI's last known valuation. Run-rate revenue crossed $47 billion earlier in May, and the company is projecting $10.9 billion in Q2 2026 revenue, up 130% from Q1. The stated use of funds: more compute, safety and interpretability research, and scaling the enterprise partnerships driving that growth.
+
+### Opus 4.8 Ships the Same Day
+
+[Claude Opus 4.8 launched on May 28](https://9to5mac.com/2026/05/28/anthropic-upgrades-claude-with-new-opus-4-8-model-heres-whats-new/), Anthropic's new top-of-range model in the Claude 4 family, timed alongside the funding announcement. It joins Claude Sonnet 4.6 and Haiku 4.5 as the third model in the current family. If you have production workloads on Opus 4.7 or earlier, benchmarking against 4.8 is the immediate next step.
+
+### Karpathy Joins to Rebuild Pretraining
+
+Andrej Karpathy, OpenAI co-founder and creator of the Neural Networks: Zero to Hero course, [joined Anthropic to rebuild its pretraining research team from the inside](https://www.buildfastwithai.com/blogs/ai-news-today-may-25-2026). Pretraining is where base model capability gets set. This is one of the most consequential talent moves in the industry this year, and the effects will show up in model releases 12 to 24 months from now.
+
+---
+
+## Governance Gets Real
+
+### OpenAI's Frontier Governance Framework
+
+On May 29, OpenAI published its [Frontier Governance Framework](https://openai.com/news/), committing to provide governments with early model access before public release for safety evaluation. Microsoft and xAI made similar commitments. This formalises what the US government has been pushing for since early 2026. For enterprise teams, the practical implication is that regulatory review will become part of the model release timeline, and compliance teams will need to track it the same way they track SOC 2 or GDPR updates.
+
+---
+
+## Enterprise AI and the Restructuring Wave
+
+### Intuit Cuts 3,000 Jobs
+
+Intuit [laid off 17% of its workforce (approximately 3,000 people) on May 20](https://techcrunch.com/2026/05/20/intuit-to-lay-off-over-3000-employees-to-refocus-on-ai/), citing a push to reduce management layers and fund AI product development. The CEO told CNBC the cuts had "nothing to do with AI," but the list of companies following this pattern now includes Salesforce, Microsoft, Google, Meta, and Intuit in the same year. The roles disappearing are coordination-heavy and duplicative functions, exactly the categories AI tooling reaches first.
+
+### Claude Managed Agents Gets Self-Hosted Sandboxes
+
+On May 26, Anthropic [shipped self-hosted sandbox support for Claude Managed Agents](https://9to5mac.com/2026/05/07/anthropic-updates-claude-managed-agents-with-three-new-features/), letting enterprise teams run tool execution on their own infrastructure (Cloudflare, Daytona, Modal, Vercel, or custom). Combined with new MCP tunnel support for private networks, this makes Claude agents workable inside enterprise security perimeters without tool results passing through Anthropic's infrastructure. For teams blocked on data residency or network isolation requirements, this removes the main blocker.
+
+---
+
+## Quick Hits
+
+- **OpenAI IPO:** OpenAI [filed a confidential draft registration with the SEC on May 22](https://techcrunch.com/2026/05/28/anthropic-raises-65-billion-nears-1t-valuation-ahead-of-ipo/), targeting a September 2026 listing. Goldman Sachs and Morgan Stanley are co-leading at a valuation range of $852 billion to $1 trillion.
+- **Gemini 3.5 Flash GA:** Google's Gemini 3.5 Flash reached general availability at [$1.50/$9 per 1M tokens](https://blog.google/innovation-and-ai/technology/developers-tools/google-io-2026-collection/) with a 1M context window, making it practical for high-volume agentic workloads where cost matters.
+- **Gartner names OpenAI a Leader in enterprise coding:** Gartner published its enterprise coding agent report on May 27, naming OpenAI a Leader based on Codex and o-series performance in code generation.
+- **Pope's AI encyclical:** Pope Leo XIV released [Magnifica Humanitas](https://www.buildfastwithai.com/blogs/ai-news-today-may-25-2026) on May 25, the first papal encyclical focused on AI, addressing "the protection of the human person in the age of artificial intelligence."
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
+
+---
+
+SOCIAL POST BRIEF — June 2, 2026
+
+Format: Carousel (Instagram/LinkedIn)
+Post on: Same day as article publication
+
+Slide 1 — Cover: "What happened in AI this week 🧠" + May 26 – June 2, 2026
+Slide 2 — Anthropic raises $65B at $965B valuation, topping OpenAI as the most valuable AI startup
+Slide 3 — Claude Opus 4.8 launches the same day as the funding round
+Slide 4 — Andrej Karpathy joins Anthropic to rebuild pretraining research
+Slide 5 — OpenAI proposes pre-release government testing for frontier models
+Slide 6 — Intuit cuts 3,000 jobs (17%) as the enterprise AI restructuring wave continues
+Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
+
+Stories to cover (pick top 4–5 for carousel):
+1. Anthropic $65B Series H at $965B valuation
+2. Claude Opus 4.8 launch
+3. Karpathy joins Anthropic
+4. OpenAI Frontier Governance Framework
+5. Intuit 17% layoffs
+
+Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
+Template: Soto to create reusable carousel template for this series.

--- a/blog/en/this-week-in-ai-2026-06-02.mdx
+++ b/blog/en/this-week-in-ai-2026-06-02.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Anthropic Raises $65B at Near-$1T Valuation, Opus 4.8 Ships, OpenAI Proposes Pre-Release Regulator Testing"
-description: "AI news recap June 2026: Anthropic closed a $65 billion Series H at a $965 billion valuation, Claude Opus 4.8 launched, and OpenAI agreed to give governments early model access before public release."
+description: "AI news recap June 2026: Anthropic raises $65B at a $965B valuation, Claude Opus 4.8 launches, and OpenAI proposes pre-release government model testing."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/977a0a26-776f-4c99-5ba1-a4cae100cd00/public"
 authorUsername: "stevekimoi"
 ---
@@ -68,27 +68,3 @@ On May 26, Anthropic [shipped self-hosted sandbox support for Claude Managed Age
 
 *This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
 
----
-
-SOCIAL POST BRIEF — June 2, 2026
-
-Format: Carousel (Instagram/LinkedIn)
-Post on: Same day as article publication
-
-Slide 1 — Cover: "What happened in AI this week 🧠" + May 26 – June 2, 2026
-Slide 2 — Anthropic raises $65B at $965B valuation, topping OpenAI as the most valuable AI startup
-Slide 3 — Claude Opus 4.8 launches the same day as the funding round
-Slide 4 — Andrej Karpathy joins Anthropic to rebuild pretraining research
-Slide 5 — OpenAI proposes pre-release government testing for frontier models
-Slide 6 — Intuit cuts 3,000 jobs (17%) as the enterprise AI restructuring wave continues
-Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
-
-Stories to cover (pick top 4–5 for carousel):
-1. Anthropic $65B Series H at $965B valuation
-2. Claude Opus 4.8 launch
-3. Karpathy joins Anthropic
-4. OpenAI Frontier Governance Framework
-5. Intuit 17% layoffs
-
-Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
-Template: Soto to create reusable carousel template for this series.

--- a/blog/en/this-week-in-ai-2026-06-02.mdx
+++ b/blog/en/this-week-in-ai-2026-06-02.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Anthropic Raises $65B at Near-$1T Valuation, Opus 4.8 Ships, OpenAI Proposes Pre-Release Regulator Testing"
 description: "AI news recap June 2026: Anthropic closed a $65 billion Series H at a $965 billion valuation, Claude Opus 4.8 launched, and OpenAI agreed to give governments early model access before public release."
-image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/73849545-e4a0-48a7-8c82-b4334fa03500/public"
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/977a0a26-776f-4c99-5ba1-a4cae100cd00/public"
 authorUsername: "stevekimoi"
 ---
 


### PR DESCRIPTION
## Summary
- Adds weekly AI news recap for May 26 to June 2, 2026
- Top stories: Anthropic $65B Series H at $965B valuation, Claude Opus 4.8 launch, Karpathy joins Anthropic, OpenAI Frontier Governance Framework, Intuit 17% layoffs
- Includes social post brief for Gosia/Soto at bottom of file

## Test plan
- [ ] Frontmatter renders correctly (title, description, image, authorUsername)
- [ ] All inline source links resolve
- [ ] No em dashes in article body
- [ ] Word count within 700–1,100 range