### PR TITLE
Add demo video to Bright Data hiring signal detector tutorial

### DIFF
--- a/tutorials/en/bright-data-hiring-signal-detector.mdx
+++ b/tutorials/en/bright-data-hiring-signal-detector.mdx
@@ -21,9 +21,9 @@ By the end you will have:
 - A Gemini-powered analyzer that returns structured JSON with signal types and cited evidence
 - A minimal dark-theme web UI where you can add companies and read their briefs side by side
 
-The full source code is on [GitHub](https://github.com/Stephen-Kimoi/bright-data-hiring-signal-detector).
-
 <LiteYouTube videoId="bm-LBWgpcgo" containerClassName={"youtubeContainer"} />
+
+The full source code is on [GitHub](https://github.com/Stephen-Kimoi/bright-data-hiring-signal-detector).
 
 ## Prerequisites
 

--- a/tutorials/en/bright-data-hiring-signal-detector.mdx
+++ b/tutorials/en/bright-data-hiring-signal-detector.mdx
@@ -7,6 +7,8 @@ authorUsername: "stevekimoi"
 
 ## Introduction
 
+<LiteYouTube videoId="bm-LBWgpcgo" containerClassName={"youtubeContainer"} />
+
 Earnings calls, analyst reports, and Bloomberg terminals all cover the same companies with the same data. But hiring activity is public, real-time, and almost nobody reads it as financial intelligence.
 
 This kind of alternative data pipeline is a strong foundation for [AI hackathon](https://lablab.ai/event) projects, especially for tracks involving market intelligence, sales tooling, or investment research. Bright Data's Web Scraper API handles live data access without proxy management, so you can build and demo a working intelligence tool within a hackathon's timeframe.
@@ -20,8 +22,6 @@ By the end you will have:
 - A Python backend with three endpoints: load watchlist, add a company, run analysis
 - A Gemini-powered analyzer that returns structured JSON with signal types and cited evidence
 - A minimal dark-theme web UI where you can add companies and read their briefs side by side
-
-<LiteYouTube videoId="bm-LBWgpcgo" containerClassName={"youtubeContainer"} />
 
 The full source code is on [GitHub](https://github.com/Stephen-Kimoi/bright-data-hiring-signal-detector).
 

--- a/tutorials/en/bright-data-hiring-signal-detector.mdx
+++ b/tutorials/en/bright-data-hiring-signal-detector.mdx
@@ -23,6 +23,8 @@ By the end you will have:
 
 The full source code is on [GitHub](https://github.com/Stephen-Kimoi/bright-data-hiring-signal-detector).
 
+<LiteYouTube videoId="bm-LBWgpcgo" containerClassName={"youtubeContainer"} />
+
 ## Prerequisites
 
 - Python 3.10 or higher


### PR DESCRIPTION
Embeds the YouTube demo (https://youtu.be/bm-LBWgpcgo) in the introduction section using the LiteYouTube component.