### PR TITLE
Add This Week in AI recap: June 1-5, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-06-08.mdx
+++ b/blog/en/this-week-in-ai-2026-06-08.mdx
@@ -1,0 +1,63 @@
+---
+title: "Anthropic Files for IPO, Microsoft Launches Its Own AI Models, ChatGPT Crosses 1 Billion Users"
+description: "AI news recap for June 1-5, 2026: Anthropic files for IPO, Microsoft launches MAI models at Build 2026, and ChatGPT crosses 1 billion monthly users."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/977a0a26-776f-4c99-5ba1-a4cae100cd00/public"
+authorUsername: "stevekimoi"
+---
+
+# Anthropic Files for IPO, Microsoft Launches Its Own AI Models, ChatGPT Crosses 1 Billion Users
+
+*This Week in AI: June 1-5, 2026*
+
+Three things happened simultaneously this week: the AI IPO race entered its opening lap, Microsoft made a visible bet on its own model stack, and ChatGPT became the fastest app in history to reach a billion monthly users. The common thread is a market moving from "who can build the smartest model" to "who controls the infrastructure, the distribution, and the public markets." That question is being answered at speed.
+
+## Key Takeaways
+
+- **Anthropic:** Filed a confidential S-1 with the SEC on June 1, beginning its path to a public offering at a $965 billion valuation and a $47 billion annualized revenue run-rate. Builders relying on Claude should expect the company's product roadmap to accelerate as IPO pressure grows.
+- **Microsoft:** Unveiled the MAI model family at Build 2026, its first AI models built entirely in-house without OpenAI's architecture. MAI-Code-1-Flash is available now; MAI-Thinking-1, a reasoning model, enters private preview. Microsoft now has the parts to compete independently.
+- **NVIDIA:** Announced RTX Spark at Computex, a Blackwell-powered Arm superchip for PCs with 128GB unified memory and one petaflop of local AI compute. More than 30 laptops arrive this fall, making serious local inference a mainstream option for the first time.
+- **ChatGPT:** Crossed 1 billion monthly active users, doing in four years what Google Search took ten to achieve. The Claude app has 56 million monthly users but is growing at 640% year over year.
+- **US Government:** Trump signed an executive order on June 2 directing agencies to deploy AI-enabled cybersecurity tools and establishing a voluntary framework for frontier model evaluation. No mandatory licensing or preclearance for developers.
+
+---
+
+## The IPO Race Begins
+
+### Anthropic Files a Confidential S-1
+
+[Anthropic submitted a confidential draft registration statement to the SEC on June 1](https://www.anthropic.com/news/confidential-draft-s1-sec), officially joining what Goldman Sachs projects could be a $160 billion IPO year. The filing follows its $65 billion Series H at a $965 billion post-money valuation, with annualized revenue crossing $47 billion. Filing confidentially gives Anthropic the option to pull back if conditions shift, but at this valuation and revenue pace the company has little reason to wait. For developers, this signals a company entering a phase where enterprise reliability and pricing stability take priority over research-first decision-making.
+
+### Three Giants Heading to Public Markets at Once
+
+SpaceX is already priced for a June 12 debut on Nasdaq under the ticker SPCX, and [OpenAI's own IPO runway is being cleared](https://news.crunchbase.com/venture/biggest-funding-rounds-ai-autonomy-biotech-anthropic/). Three of the most-watched private companies in tech are heading to public markets in the same summer, compressing years of speculation into a single quarter.
+
+---
+
+## Microsoft Declares Its Own AI Agenda
+
+### The MAI Models Change the Relationship With OpenAI
+
+At Build 2026 in San Francisco on June 2-3, Satya Nadella unveiled the MAI family: Microsoft's first AI models developed entirely in-house. [MAI-Code-1-Flash converts natural-language descriptions into working source code; MAI-Thinking-1 is a reasoning model entering private preview](https://www.cnbc.com/2026/06/02/microsoft-unveils-new-ai-models-lessen-reliance-on-openai-lower-costs.html). The launch also included MAI-Image-2.5, MAI-Transcribe-1.5 (supporting 43 languages), and MAI-Voice-2. After tuning the models for McKinsey's workflows, Microsoft reported 10x better cost efficiency than GPT-5.5 for equivalent tasks. This is the clearest public signal yet that Microsoft is building a fallback that does not depend on OpenAI's roadmap. For teams building on Azure, that means more model options and potentially sharply lower inference costs.
+
+---
+
+## AI Hardware Gets a Stake in the Ground
+
+### NVIDIA's RTX Spark Makes Local AI Compute Real
+
+[Jensen Huang opened Computex 2026 with RTX Spark](https://www.nvidia.com/en-us/geforce/news/computex-2026-nvidia-geforce-rtx-announcements/), a new Arm-based superchip pairing a Blackwell GPU (6,144 CUDA cores, fifth-generation Tensor Cores with FP4 precision) with a 20-core Grace CPU and 128GB of unified memory in a single package. The result is one petaflop of AI performance on device, without a data center. NVIDIA and Microsoft are positioning RTX Spark as a platform for running AI agents natively on Windows, with more than 30 laptops and 10 desktops from Dell, HP, Asus, Lenovo, and MSI arriving this fall. Capable local inference for agentic workloads becomes a real option for individual developers within the next six months.
+
+---
+
+## Quick Hits
+
+- **ChatGPT reaches 1 billion monthly users:** [OpenAI confirmed the milestone this week](https://www.pymnts.com/artificial-intelligence-2/2026/chatgpt-hits-1-billion-monthly-active-users-in-record-time/), making ChatGPT the fastest app in history to hit 1 billion monthly active users, ahead of Facebook, Instagram, and Google Search.
+- **Trump signs AI executive order:** The June 2 order directs federal agencies to deploy AI-enabled cybersecurity tools within 60 days and creates a voluntary framework for evaluating frontier models, with no mandatory licensing requirements for developers.
+- **xAI lands a federal contract:** The GSA signed an agreement giving all US federal agencies access to Grok 4 and Grok 4 Fast for 18 months at $0.42 per agency.
+- **Supabase raises $500M:** The open-source developer platform [closed a round at a $10.5 billion valuation](https://news.crunchbase.com/venture/biggest-funding-rounds-june-5-2026/), accelerating its positioning as infrastructure for AI app builders.
+- **BYD enters humanoid robotics:** The Chinese automaker confirmed plans to build humanoid robots, applying its battery, sensor, and software expertise to a market that is attracting serious capital.
+- **Robotaxis reach Spain:** [Uber, WeRide, and AVOMO launched Europe's first commercial robotaxi service](https://medium.com/@davidakpovi/ai-news-week-of-june-1-to-june-7-2026-7957940c805a), beginning operations in the Madrid region this week.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*

--- a/blog/en/this-week-in-ai-2026-06-08.mdx
+++ b/blog/en/this-week-in-ai-2026-06-08.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Anthropic Files for IPO, Microsoft Launches Its Own AI Models, ChatGPT Crosses 1 Billion Users"
 description: "AI news recap for June 1-5, 2026: Anthropic files for IPO, Microsoft launches MAI models at Build 2026, and ChatGPT crosses 1 billion monthly users."
-image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/977a0a26-776f-4c99-5ba1-a4cae100cd00/public"
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/472fbfc4-f5a4-413c-b69d-746b42462500/public"
 authorUsername: "stevekimoi"
 ---
 


### PR DESCRIPTION
## Summary

- Adds the weekly AI news recap for June 1-5, 2026
- Top stories: Anthropic files confidential S-1 with SEC, Microsoft debuts MAI model family at Build 2026, NVIDIA RTX Spark at Computex, ChatGPT crosses 1 billion users
- Quick hits: Trump AI executive order, xAI/GSA federal contract, Supabase $500M raise, BYD enters robotics, Uber/WeRide Madrid robotaxi launch

## Test plan

- [ ] Review article at `blog/en/this-week-in-ai-2026-06-08.mdx`
- [ ] Upload a new cover image to Cloudflare Images and update the `image` field in frontmatter (reusing June 2 cover for now)
- [ ] Share social post brief with Gosia + Soto (see brief below)
- [ ] Merge and verify article is live on lablab.ai

## Social post brief (for Gosia + Soto)

**Format:** Carousel (Instagram/LinkedIn) — post same day as publication

- Slide 1: "What happened in AI this week" + June 1-5, 2026
- Slide 2: Anthropic files for IPO — Confidential S-1 to SEC, valued at $965B with $47B annualized revenue
- Slide 3: Microsoft launches its own AI — MAI model family at Build 2026, no OpenAI architecture, 10x cost efficiency vs GPT-5.5
- Slide 4: NVIDIA RTX Spark — Arm superchip with 128GB memory and 1 petaflop of on-device AI, 30+ laptops this fall
- Slide 5: ChatGPT hits 1 billion users — fastest app in history, 4 years vs Google Search's 10
- Slide 6: CTA — "Full breakdown at lablab.ai. Link in bio."

Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.