### PR TITLE
Add Band technology page

### DIFF
--- a/technologies/band-ai/index.mdx
+++ b/technologies/band-ai/index.mdx
@@ -1,0 +1,80 @@
+---
+title: "Band"
+description: "Band is an interaction infrastructure platform that lets AI agents built on different frameworks discover each other, exchange context, and coordinate through shared chat rooms with built-in governance."
+---
+
+# Band
+
+Band, operated by Thenvoi AI Ltd., was founded in 2025 by CEO Arick Goomanovsky and CTO Vlad Luzin to give AI agents a shared way to find each other, delegate work, and collaborate safely across frameworks, clouds, and organizations. The platform is often described as "Slack for agents": each agent keeps its own models, tools, and memory, while Band provides the chat rooms, identity, and governance layer that ties them together with humans in the loop.
+
+| General | |
+|---------|--|
+| **Company** | [Band](https://www.band.ai) (Thenvoi AI Ltd.) |
+| **Founded** | 2025 by Arick Goomanovsky and Vlad Luzin |
+| **Headquarters** | Kochav Ya'ir, Israel |
+| **Website** | [band.ai](https://www.band.ai) |
+| **Documentation** | [docs.band.ai](https://docs.band.ai) |
+| **GitHub** | [github.com/thenvoi](https://github.com/thenvoi) |
+| **Type** | AI Agent Infrastructure, Multi-Agent Coordination Platform |
+
+---
+
+## Core Products
+
+### Agentic Mesh
+
+The collaboration layer where any agent, regardless of framework, can discover other agents, exchange structured messages, share context, and delegate tasks through chat rooms with @mention-based routing.
+
+### Control Plane
+
+Governance tooling that gives teams visibility into agent-to-agent interactions, lets them set authority and delegation boundaries, and keeps a unified audit trail across every agent connected to the network.
+
+---
+
+## Developer Resources
+
+Band ships a Python SDK with adapters for popular agent frameworks, a TypeScript SDK, and an MCP server so coding assistants like Claude Code and Cursor can join Band rooms directly.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.band.ai): getting started guides, core concepts, and SDK reference
+- [GitHub](https://github.com/thenvoi): Python and TypeScript SDKs, MCP server, and example agents
+- [Discord](https://discord.com/invite/5YkNXmYfjk): community support and announcements
+- [App / Console](https://app.band.ai): create agents, manage contacts, and open chat rooms
+
+---
+
+## Key Features
+
+**Cross-framework agent connections**
+Agents built with LangGraph, CrewAI, Anthropic, Pydantic AI, Parlant, Google ADK, OpenCode, or custom code connect through the same SDK and join shared chat rooms without writing point-to-point integration code.
+
+**Persistent identity and contacts**
+Each agent gets a persistent identity and handle, with a contact system that controls cross-boundary visibility and consent before two agents can interact.
+
+**Chat rooms with @mention routing**
+Agents and humans collaborate in shared rooms where @mentions route messages to the right participant, supporting multi-agent workflows such as planner, reviewer, and implementer roles.
+
+**Governance and audit trail**
+Authority boundaries, delegation policies, and a unified audit trail give enterprises visibility into what every agent did and why.
+
+**MCP server for coding agents**
+An MCP server lets Claude Code, Cursor, and other MCP-compatible tools join Band rooms and coordinate with other coding agents over a shared repository.
+
+---
+
+## Use Cases
+
+**Coordinating coding agents**
+Teams run Claude Code as a planner and Codex as a reviewer in a shared Docker workspace, with both agents reading the same git repository, writing plans and reviews to shared files, and coordinating through a Band chat room.
+
+**AI governance and standardization**
+Organizations use Band's control plane to standardize how agents delegate work, request approval, and get audited across teams and external vendors.
+
+**Multi-agent lifecycle management**
+Long-running, multi-step agent work stays visible in shared rooms so humans can step in, redirect, or approve at any point.
+
+**Personal AI assistants**
+Individuals run personal agents such as OpenClaw or NanoClaw and connect them to Band so assistants on different machines or households can collaborate while keeping their own data and runtime isolated.


### PR DESCRIPTION
## Summary
- Adds a new company index page for Band (band.ai), an AI agent interaction/coordination infrastructure platform (Thenvoi AI Ltd.)
- Covers core products (Agentic Mesh, Control Plane), SDKs/MCP server, key features, and use cases, sourced from band.ai, docs.band.ai, and launch coverage (VentureBeat, Team8)

## Test plan
- [x] Frontmatter has title and description
- [x] `<TechTutorials/>` included in Developer Resources
- [x] No em dashes, placeholders, or marketing language
- [x] All linked URLs (band.ai, docs.band.ai, github.com/thenvoi, Discord) verified to resolve