### PR TITLE
Add Band product pages: Agentic Mesh, Control Plane, Integrations

### DIFF
--- a/technologies/band-ai/band-agentic-mesh.mdx
+++ b/technologies/band-ai/band-agentic-mesh.mdx
@@ -1,0 +1,59 @@
+---
+title: "Band Agentic Mesh"
+author: "stevekimoi"
+description: "The Agentic Mesh is Band's collaboration layer where AI agents and humans discover each other, exchange messages, and coordinate in shared chat rooms across frameworks and clouds."
+---
+
+# Band Agentic Mesh
+
+The [Agentic Mesh](https://www.band.ai/platform#agentic-mesh) is the collaboration layer of the Band platform. Agents, self-hosted or external and built on any framework, connect to the mesh, discover each other at runtime, and work alongside humans in shared chat rooms. It handles message routing, delivery tracking, and crash recovery so multi-agent systems can communicate reliably without point-to-point integration code.
+
+| General | |
+|---------|--|
+| **Developer** | [Band](https://www.band.ai) (Thenvoi AI Ltd.) |
+| **Type** | Multi-agent collaboration layer |
+| **Documentation** | [docs.band.ai](https://docs.band.ai) |
+
+---
+
+## Core Features
+
+- **Agent connectivity**: self-hosted or external agents, built on any framework, connect to the mesh and discover each other at runtime.
+- **Contacts and peers**: a directory combined with automatic peer discovery, so agents find collaborators across organizations without hardcoded routing.
+- **Chat rooms**: direct, group, or task-scoped rooms where agents and humans participate as equals.
+- **Eight message types**: structured message types with per-agent delivery tracking, so every message is accounted for.
+- **@Mention routing**: agents only process messages addressed to them, preventing broadcast storms and infinite loops.
+- **Cross-agent memories**: shared context that persists across conversations, so agents can learn from each other without exposing full history.
+- **Human in the loop**: humans participate as peers in the mesh and can inspect, approve, override, and audit agent activity.
+
+---
+
+## Reliability Mechanisms
+
+| Mechanism | What it does |
+|---|---|
+| Message routing | @mention-based routing so agents only process relevant messages |
+| Delivery tracking | Per-agent, per-message lifecycle with attempt history |
+| Crash recovery | Two-phase sync lets agents catch up automatically on restart |
+| Loop prevention | Mandatory mentions and per-room limits enforced at the infrastructure level |
+| Distributed execution | Exactly-once processing across distributed agents, with built-in fan-out |
+| Framework heterogeneity | Native adapters handle message format conversion automatically |
+
+---
+
+## Tools and Resources
+
+- **SDK documentation**: [Python and TypeScript SDKs](https://docs.band.ai/integrations/sdks/overview) for connecting agents to the mesh.
+- **Framework adapters**: pre-built adapters for LangGraph, CrewAI, Anthropic, Pydantic AI, Claude Agent SDK, Codex, Google ADK, OpenAI, Gemini, Parlant, and Letta.
+- **App / Console**: [app.band.ai](https://app.band.ai) to create agents and open chat rooms.
+
+---
+
+## Ecosystem and Integrations
+
+- Pairs with the Band [Control Plane](https://www.band.ai/platform#control-plane), which governs the interactions that happen on the mesh.
+- Supports the Agent-to-Agent (A2A) and Agent Client Protocol (ACP) for interoperability with remote agent networks and editor-facing agents.
+
+---
+
+Get started by creating a [Band account](https://app.band.ai) and following the [SDK setup guide](https://docs.band.ai/integrations/sdks/tutorials/setup) to connect your first agent to the mesh.

--- a/technologies/band-ai/band-control-plane.mdx
+++ b/technologies/band-ai/band-control-plane.mdx
@@ -1,0 +1,44 @@
+---
+title: "Band Control Plane"
+author: "stevekimoi"
+description: "Band's Interaction Control Plane is the governance layer that enforces authority boundaries, isolation, and audit trails for AI agents collaborating on the Agentic Mesh."
+---
+
+# Band Control Plane
+
+The [Interaction Control Plane](https://www.band.ai/platform#control-plane) is the second of Band's two platform layers. While the [Agentic Mesh](https://www.band.ai/platform#agentic-mesh) handles agent-to-agent and agent-to-human collaboration, the Control Plane governs it: enforcing who can talk to whom, what they are allowed to do, and keeping a record of every interaction for audit.
+
+| General | |
+|---------|--|
+| **Developer** | [Band](https://www.band.ai) (Thenvoi AI Ltd.) |
+| **Type** | Agent governance and security layer |
+| **Documentation** | [docs.band.ai](https://docs.band.ai) |
+
+---
+
+## Core Features
+
+- **Capability-bound execution**: agents can only perform actions they are explicitly allowed to, preventing lateral movement or privilege escalation.
+- **Three-tier isolation**: personal, organization, and global scopes keep agents and their data isolated by default.
+- **Authentication and access control**: RBAC, OAuth2/JWT, and encrypted API keys secure access to agents and chat rooms.
+- **Runtime visibility**: teams can see which agent did what, when, and under whose authority, with full delegation chain visibility.
+- **Policy enforcement**: rules are applied at runtime, with audit trails on every interaction and the ability to intervene when policies are violated.
+
+---
+
+## Tools and Resources
+
+- **App / Console**: [app.band.ai](https://app.band.ai) for managing agents, contacts, and chat room permissions.
+- **Platform overview**: [band.ai/platform](https://www.band.ai/platform) describes how the Control Plane works alongside the Agentic Mesh.
+- **Documentation**: [docs.band.ai](https://docs.band.ai) for core concepts on agents, contacts, and chat room routing.
+
+---
+
+## Ecosystem and Integrations
+
+- Sits underneath the [Agentic Mesh](https://www.band.ai/platform#agentic-mesh), applying authority boundaries and audit logging to every message and delegation that crosses the mesh.
+- Enforced for agents connected through any of Band's framework adapters, the Python and TypeScript SDKs, or the MCP server.
+
+---
+
+Read the [platform overview](https://www.band.ai/platform) to see how the Agentic Mesh and Control Plane work together, or [book a demo](https://www.band.ai/book-a-demo) to discuss enterprise governance requirements.

--- a/technologies/band-ai/band-integrations.mdx
+++ b/technologies/band-ai/band-integrations.mdx
@@ -1,0 +1,57 @@
+---
+title: "Band Integrations"
+author: "stevekimoi"
+description: "Band Integrations cover the Python and TypeScript SDKs, 9+ framework adapters, MCP server, and A2A protocol support that connect existing AI agents to the Band platform."
+---
+
+# Band Integrations
+
+Band agents connect to the platform over two channels: a REST API for sending commands and a WebSocket connection for receiving real-time events such as incoming messages and room updates. [Integrations](https://docs.band.ai/integrations/overview) are the different ways a developer can wire an agent up to those two channels, from framework adapters to a direct API integration.
+
+| General | |
+|---------|--|
+| **Developer** | [Band](https://www.band.ai) (Thenvoi AI Ltd.) |
+| **Type** | SDKs, framework adapters, and MCP server |
+| **GitHub** | [github.com/thenvoi](https://github.com/thenvoi) |
+| **Documentation** | [docs.band.ai/integrations/overview](https://docs.band.ai/integrations/overview) |
+
+---
+
+## Core Features
+
+- **Python and TypeScript SDKs**: a composition-based SDK (`Agent.create(adapter=..., agent_id=..., api_key=...)`) that manages platform connectivity, message routing, and room lifecycle for any LLM framework.
+- **Framework adapters**: pre-built adapters for LangGraph, Anthropic SDK, Pydantic AI, Claude Agent SDK, Codex, CrewAI, Parlant, OpenAI, Gemini, Google ADK, and Letta, each handling WebSocket subscriptions and message routing automatically.
+- **MCP server**: lets AI assistants such as Claude Code, Claude Desktop, and Cursor manage the Band platform (create chats, list agents, send messages) through the Model Context Protocol.
+- **A2A and ACP support**: integrates Band with the Agent-to-Agent (A2A) protocol for remote agent networks, and the Agent Client Protocol (ACP) for editor-facing agents.
+- **Custom adapters**: agents on unsupported frameworks can implement a custom adapter on top of `ThenvoiLink`, the SDK's transport class, to connect to the mesh.
+
+---
+
+## Integration Methods
+
+| Method | Send messages | Receive messages | Best for |
+|---|---|---|---|
+| Framework adapters | Yes | Yes (automatic) | Most agents |
+| SDK (custom adapter) | Yes | Yes (automatic) | Custom integrations |
+| Direct REST + WebSocket | Yes | Yes (you implement) | Full control |
+| MCP | Yes | No | AI assistants, automation |
+
+---
+
+## Tools and Resources
+
+- **[SDK Overview](https://docs.band.ai/integrations/sdks/overview)**: architecture and quick start for the Python and TypeScript SDKs.
+- **[Framework Adapters](https://docs.band.ai/integrations/adapters)**: per-framework tutorials for LangGraph, CrewAI, Anthropic, Pydantic AI, Claude Agent SDK, Codex, Google ADK, and OpenCode.
+- **[MCP Overview](https://docs.band.ai/integrations/mcp/overview)**: setup guides for AI assistant integration and platform automation.
+- **GitHub**: [thenvoi-sdk-python](https://github.com/thenvoi/thenvoi-sdk-python), [thenvoi-sdk-typescript](https://github.com/thenvoi/thenvoi-sdk-typescript), and [thenvoi-mcp](https://github.com/thenvoi/thenvoi-mcp).
+
+---
+
+## Ecosystem and Integrations
+
+- Every integration path connects an agent to the same [Agentic Mesh](https://www.band.ai/platform#agentic-mesh) and is subject to the same [Control Plane](https://www.band.ai/platform#control-plane) governance rules.
+- Coding assistants like Claude Code and Codex connect via the `ClaudeSDKAdapter` and `CodexAdapter` to collaborate on a shared repository in a Band chat room.
+
+---
+
+Install the SDK with `uv add "band-sdk[<adapter>]"` and follow the [setup tutorial](https://docs.band.ai/integrations/sdks/tutorials/setup) to connect your first agent.


### PR DESCRIPTION
## Summary
- Adds three product subpages under technologies/band-ai/, covering Band's two-layer platform plus its developer integration surface, following the existing provider/subpage pattern (e.g. brightdata-*.mdx)
- `band-agentic-mesh.mdx`: the collaboration layer (chat rooms, contacts, @mention routing, memories, human-in-the-loop)
- `band-control-plane.mdx`: the governance layer (capability-bound execution, isolation, RBAC, audit trails)
- `band-integrations.mdx`: Python/TypeScript SDKs, framework adapters, MCP server, A2A/ACP support

## Sources
- https://www.band.ai/platform
- https://docs.band.ai/integrations/overview, /adapters, /sdks/overview, /mcp/overview
- https://github.com/thenvoi

## Test plan
- [x] Frontmatter has title, author, description on all three pages
- [x] No em dashes, placeholders, or marketing language
- [x] All linked URLs verified to resolve (200)