### PR TITLE
Add This Week in AI recap: June 8-15, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-06-15.mdx
+++ b/blog/en/this-week-in-ai-2026-06-15.mdx
@@ -1,0 +1,94 @@
+---
+title: "Anthropic's Newest Models Banned, Apple Opens iOS to Claude and Gemini, Meta's AI Pivot Turns Ugly"
+description: "AI news recap for June 8-15, 2026: the US Commerce Department orders Anthropic to disable Claude Fable 5 and Mythos 5, Apple opens iOS to Claude and Gemini at WWDC 2026, and Meta's AI restructuring sparks a public employee revolt."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/f85b1cd0-1a83-46a9-7de0-0fe96a639b00/public"
+authorUsername: "stevekimoi"
+---
+
+# Anthropic's Newest Models Banned, Apple Opens iOS to Claude and Gemini, Meta's AI Pivot Turns Ugly
+
+*This Week in AI: June 8-15, 2026*
+
+This week was about who gets to control access to AI, not what the models can do. Washington drew a hard border around Anthropic's newest models, Apple tore down part of its walled garden to let outside AI in, and Meta's internal restructuring cracked open in public. Three companies, three very different fights over the same question.
+
+## Key Takeaways
+
+- **Anthropic:** The US Commerce Department ordered Anthropic to disable Claude Fable 5 and Mythos 5 for all non-US users on June 12 — three days after launch — under emergency export-control powers, the first retroactive ban of a shipped commercial AI model. Anyone building production workflows on frontier models now has to plan for a regulator, not a vendor, pulling the plug.
+- **Apple:** At WWDC, Apple's new LanguageModel protocol lets iOS and macOS developers swap between Apple's on-device model, Claude, and Gemini through the same Swift API, and Foundation Models on Private Cloud Compute is now free for apps under 2 million downloads. Shipping an AI feature on Apple platforms just got cheaper and far less locked-in.
+- **Meta:** An employee publicly called a senior AI executive "a piece of sh*t" during a livestreamed all-hands on June 12, and Zuckerberg responded with a memo admitting "we've made mistakes" while ruling out further company-wide layoffs in 2026. The reorg that touched roughly a fifth of Meta's workforce is now generating visible internal blowback.
+- **OpenAI:** GPT-5.2 quietly vanished from ChatGPT's model picker on June 12, with existing chats auto-rerouted to GPT-5.5, while OpenAI separately acquired cloud startup Ona to let Codex agents run multi-hour tasks outside a single session. If your workflows are pinned to GPT-5.2 via the API, start testing GPT-5.5 now.
+- **xAI:** Grok Build shipped a plugin marketplace on June 11 with day-one integrations from MongoDB, Vercel, Sentry, Cloudflare, and Chrome DevTools — a direct answer to Claude Code's plugin ecosystem. Coding agents are now competing on extensions as much as on raw model quality.
+
+---
+
+## Washington Draws a Hard Line Around Frontier AI
+
+### The US Government Bans Claude Fable 5 and Mythos 5
+
+[Anthropic launched Claude Fable 5 and Mythos 5 on June 9](https://www.marktechpost.com/2026/06/13/anthropic-disables-claude-fable-5-and-mythos-5-after-us-government-order/), its newest frontier models. Three days later, Commerce Secretary Howard Lutnick sent a letter to CEO Dario Amodei invoking emergency national-security authority to suspend access for all non-US persons, after [an administration official told Axios](https://www.axios.com/2026/06/12/anthropic-trump-mythos-fable-national-security) a rival lab had claimed it jailbroken Mythos 5 well enough to extract sensitive information. Because [Anthropic can't filter foreign nationals from US traffic in real time](https://www.cnbc.com/2026/06/12/anthropic-disables-access-to-fable-5-and-mythos-5-to-comply-with-government-directive.html), it shut both models down globally — including for its own foreign employees.
+
+This is the first time the US government has retroactively pulled a shipped commercial AI model via export controls. Every frontier lab now has to plan around a new failure mode: a model can ship, get adopted, and disappear within a week for reasons entirely outside the vendor's control.
+
+---
+
+## Apple Cracks Open the Walled Garden
+
+### Foundation Models Learns to Speak Claude and Gemini
+
+At its [Platforms State of the Union on June 9](https://www.macrumors.com/2026/06/09/apple-outlines-major-ai-and-developer-tool-updates/), Apple introduced a LanguageModel protocol that gives developers one API for Apple's on-device model, Anthropic's Claude, and Google's Gemini — [switching providers takes a few lines of code, not a rewrite](https://www.techtimes.com/articles/318039/20260609/wwdc-2026-developer-tools-foundation-models-now-swaps-ai-providers-without-code-changes.htm). Apple also made Foundation Models on Private Cloud Compute free for any app with fewer than 2 million first-time downloads, removing inference cost as a reason not to ship an AI feature. The framework picks up image input support and a Dynamic Profiles system for multi-agent apps, and Apple says the whole thing goes open source later this summer.
+
+For indie developers, the calculus on "should this app have an AI feature" just changed — the infrastructure cost that used to make that a hard no is gone.
+
+### Xcode 27 Ships With Agents Built In
+
+Xcode 27 now runs on two engines: a local Neural Engine model for real-time Swift autocomplete, and a cloud routing layer that hands heavier work to Claude, Gemini, or OpenAI's agents depending on what the developer configures. Combined with the LanguageModel protocol, Apple's IDE is effectively model-agnostic by default — a notable shift for a company that built its AI pitch on "private and on-device," now explicitly routing work to its biggest competitors' models when its own isn't enough.
+
+---
+
+## Meta's AI Pivot Turns Ugly
+
+### An Employee Revolt Goes Out Live
+
+During a livestreamed internal presentation on June 12, [a Meta employee took the microphone and called a senior AI executive "a piece of sh*t" in front of thousands of colleagues](https://www.yahoo.com/news/politics/articles/meta-employee-hijacks-livestreamed-meeting-235451123.html). Hours later, [Zuckerberg sent a memo acknowledging "we've made mistakes" with the AI reorg](https://ts2.tech/en/meta-adjusts-ai-plans-zuckerberg-says-missteps-followed-staff-pushback/) and promised no further company-wide layoffs for the rest of 2026. The reorg in question moved roughly 8,000 people out and reassigned another 7,000 into a new Applied AI unit — about a fifth of Meta's workforce touched in one cycle.
+
+When a restructuring this size produces a public meltdown on a livestream, it's a signal that the "move fast" approach to AI org design has a human cost that's now visible to competitors and recruiters alike.
+
+### Meta Unwinds Its Manus Acquisition
+
+Separately, [Meta began splitting operations and cutting off data access with Manus](https://www.bloomberg.com/news/articles/2026-06-11/meta-severs-manus-data-access-after-china-orders-buyout-unwound), unwinding a roughly $2 billion acquisition after Beijing ordered the deal reversed. The split removes a Chinese AI agent startup from Meta's stack just as the company tries to consolidate its AI strategy under one roof — another reminder that cross-border AI deals are getting harder to close, and easier to unwind, as both Washington and Beijing tighten their grip.
+
+---
+
+## Quick Hits
+
+- **OpenAI:** GPT-5.2 [disappeared from ChatGPT's model picker on June 12](https://www.techtimes.com/articles/318345/20260613/openai-retires-gpt-52-moves-everyone-gpt-55-what-changes-chatgpt-users-developers.htm), with existing conversations auto-continuing on GPT-5.5 and no advance warning despite an August 10 shutdown date on OpenAI's own deprecation page.
+- **OpenAI acquires Ona:** [OpenAI is buying German cloud startup Ona](https://www.cnbc.com/2026/06/11/open-ai-ona-acquisition-codex.html) (formerly Gitpod) to let Codex agents run for hours outside a single session; Codex now has more than 5 million weekly users, up 400% since earlier this year.
+- **xAI:** [Grok Build's Plugin Marketplace launched June 11](https://www.marktechpost.com/2026/06/11/xai-ships-grok-build-plugin-marketplace-with-mongodb-vercel-sentry-chrome-devtools-cloudflare-and-superpowers-plugins-at-launch/) with bundled integrations for MongoDB, Vercel, Sentry, Cloudflare, Chrome DevTools, and Superpowers — install from the terminal without leaving Grok Build.
+- **NHS:** [England's health service is rolling out Microsoft 365 Copilot to 505,000 staff](https://thenextweb.com/news/nhs-england-microsoft-copilot-505000-staff-ai-rollout) in a £120 million deal, one of the largest enterprise AI deployments anywhere, after pilots saved clinicians an average of 47 minutes a day.
+- **DeepSeek:** The Chinese AI lab is closing in on [its first-ever outside funding round](https://www.bloomberg.com/news/articles/2026-06-03/deepseek-close-to-sealing-7-billion-funding-in-historic-ai-deal) — roughly $7.4 billion from Tencent, CATL, and China's national AI fund at a valuation up to $59 billion.
+- **SpaceX and Google:** Ahead of its Nasdaq listing, [SpaceX disclosed a deal to lease Google about 110,000 NVIDIA GPUs for $920 million a month](https://techcrunch.com/2026/06/05/google-will-pay-spacex-920m-per-month-for-compute/), a contract worth roughly $32 billion through 2029.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
+
+---
+
+SOCIAL POST BRIEF — June 15, 2026
+
+Format: Carousel (Instagram/LinkedIn)
+Post on: Same day as article publication
+
+Slide 1 — Cover: "What happened in AI this week 🧠" + June 15, 2026
+Slide 2-6 — One story per slide: bold headline + 1-sentence summary
+Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
+
+Stories to cover (pick top 4-5 for carousel):
+1. US government bans Anthropic's Claude Fable 5 and Mythos 5, three days after launch
+2. Apple opens iOS and macOS to Claude and Gemini via new LanguageModel protocol
+3. Meta employee calls AI exec "a piece of sh*t" live on stream; Zuckerberg admits "mistakes"
+4. OpenAI quietly retires GPT-5.2, acquires Ona to power longer-running Codex agents
+5. xAI launches Grok Build Plugin Marketplace with MongoDB, Vercel, Sentry, Cloudflare
+
+Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
+Template: Soto's reusable carousel template from the June 8 edition.


### PR DESCRIPTION
## Summary
- New "This Week in AI" recap covering June 8-15, 2026
- Lead stories: US Commerce Dept disables Anthropic's Claude Fable 5 & Mythos 5 under export controls, Apple opens iOS/macOS to Claude and Gemini via WWDC's new LanguageModel protocol, and Meta's AI restructuring sparks a public employee revolt
- Quick hits: OpenAI retires GPT-5.2 / acquires Ona, xAI ships Grok Build's plugin marketplace, NHS-Microsoft Copilot rollout, DeepSeek funding round, SpaceX-Google GPU deal
- Includes social post brief for Gosia/Soto at the bottom of the file

## Outstanding before merge
- [ ] **Cover image** — `image` field currently reuses the April 28 cover (`f85b1cd0-...`) as a placeholder. Needs a fresh image generated/uploaded to Cloudflare Images (CLOUDFLARE_IMAGES_TOKEN not available in this environment).
- [ ] **Notion task** — could not check/update the "AI News Recap" task (NOTION_TOKEN not available in this environment).

## Test plan
- [ ] Verify all source links resolve
- [ ] Replace cover image and confirm frontmatter renders correctly
- [ ] Review Meta section tone (includes a quoted profanity from source reporting)