### PR TITLE
Fix GFM pipe table rendering in Band SDK tutorial; add check to publish-check skill

### DIFF
--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -40,6 +40,7 @@ Read the full draft file.
 
 - [ ] **1,200–2,500 words** — count and flag if outside range
 - [ ] **All code blocks are runnable** — no partial snippets; every block includes all imports
+- [ ] **No GFM pipe tables** — the lablab.ai MDX renderer does not support markdown pipe-syntax tables (`| col |`). Every table must use raw HTML: `<table><thead><tr><th>…</th></tr></thead><tbody><tr><td>…</td></tr></tbody></table>`. Use `<code>` tags (not backticks) for inline code inside table cells.
 - [ ] **Language declared** on every fenced code block (` ```python `, ` ```typescript `, etc.)
 - [ ] **Prerequisites section present** — tools, API keys, framework versions listed
 - [ ] **`.env` format shown** (if needed) — with placeholder values, never real keys

--- a/tutorials/en/band-sdk-aimlapi-pipeline-tutorial.mdx
+++ b/tutorials/en/band-sdk-aimlapi-pipeline-tutorial.mdx
@@ -144,12 +144,17 @@ await agent.run()
 
 `Agent.from_config` connects to Band using the credentials in `agent_config.yaml`. `PydanticAIAdapter` wraps a PydanticAI model and exposes four file-system tools to every agent:
 
-| Tool | What it does |
-|------|-------------|
-| `read_file(path)` | Read a file from `workspace/` |
-| `write_file(path, content)` | Write a file to `workspace/` |
-| `list_files(path)` | List files under a path in `workspace/` |
-| `run_tests(path)` | Run `pytest` on a directory in `workspace/` and return output |
+<table>
+  <thead>
+    <tr><th>Tool</th><th>What it does</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>read_file(path)</code></td><td>Read a file from <code>workspace/</code></td></tr>
+    <tr><td><code>write_file(path, content)</code></td><td>Write a file to <code>workspace/</code></td></tr>
+    <tr><td><code>list_files(path)</code></td><td>List files under a path in <code>workspace/</code></td></tr>
+    <tr><td><code>run_tests(path)</code></td><td>Run <code>pytest</code> on a directory in <code>workspace/</code> and return output</td></tr>
+  </tbody>
+</table>
 
 All paths are sandboxed to `workspace/` — a path traversal check in `tools.py` prevents agents from reading or writing outside it. Full implementation in [`agents/tools.py`](https://github.com/Stephen-Kimoi/band-3-agent-delivery-pipeline/blob/main/agents/tools.py).
 


### PR DESCRIPTION
## Summary

- Converts the GFM pipe-syntax tools table in the Band SDK pipeline tutorial to HTML `<table>` — the lablab.ai MDX renderer does not process markdown pipe tables and was rendering them as raw text
- Adds a `No GFM pipe tables` checklist item to `.agents/skills/publish-check/SKILL.md` so this mistake is caught on every future tutorial before it ships

## What was broken

The tools table in Step 4 was rendering as a single inline string of pipe characters instead of a formatted table. Root cause: lablab.ai's MDX config does not enable the `remarkGfm` table plugin, so `| col |` syntax is treated as plain text.

## Fix

Replaced pipe table with raw HTML (`<table><thead><tr><th>…`) and `<code>` tags for inline code in cells, matching the pattern already used in `native-builder-getting-started.mdx`.