### PR TITLE
Add tech pages for ExecuTorch hackathon technology partners

### DIFF
--- a/technologies/github/github-copilot.mdx
+++ b/technologies/github/github-copilot.mdx
@@ -1,0 +1,87 @@
+---
+title: "GitHub Copilot"
+author: "github"
+description: "GitHub Copilot is an AI coding assistant that provides inline completions, conversational chat, autonomous agent mode, and cloud-based coding agents across all major IDEs and GitHub.com, with support for multiple LLM providers including OpenAI, Anthropic, and Google."
+---
+
+# GitHub Copilot
+
+[**GitHub Copilot**](https://github.com/features/copilot) is an AI-powered development assistant built by GitHub in partnership with OpenAI and Microsoft. Originally launched in technical preview in June 2021 and reaching general availability in June 2022, Copilot has expanded from single-line code completions into a full agentic platform that can autonomously edit multiple files, run terminal commands, and open pull requests with minimal human direction. It is now embedded across GitHub.com, major IDEs, the CLI, GitHub Mobile, and Windows Terminal.
+
+| General | |
+|---------|--|
+| **GA date** | 21 Jun 2022 |
+| **Developer** | GitHub (Microsoft) |
+| **Type** | AI Coding Assistant |
+| **License** | Commercial SaaS |
+| **Documentation** | [docs.github.com/en/copilot](https://docs.github.com/en/copilot) |
+
+---
+
+## Core Features
+
+- **Inline code completions** — context-aware autocomplete in supported editors; includes next-edit predictions in VS Code, Xcode, and Eclipse.
+- **Copilot Chat** — conversational interface for code explanation, refactoring, debugging, and Q&A; available in IDEs, GitHub.com, GitHub Mobile, and Windows Terminal.
+- **Agent Mode (IDEs)** — autonomous in-IDE operation that edits multiple files, runs terminal commands, self-corrects errors, and iterates until a task is complete.
+- **Cloud Coding Agent** — an async agent assigned via a GitHub issue that researches the repo, writes an implementation plan, and opens a pull request.
+- **Copilot Code Review** — AI-generated pull request review suggestions surfaced inline on the PR diff.
+- **PR Summaries** — auto-generated descriptions of pull request changes for reviewers.
+- **Copilot CLI** — natural-language terminal assistance (GA April 2026).
+- **MCP Server Integration** — any Model Context Protocol server works as a Copilot extension, replacing the deprecated Copilot Extensions API.
+- **Multi-model selection** — choose from OpenAI models, Anthropic Claude (including Opus), Google Gemini, and others on Pro+ and above plans.
+- **Copilot Spaces** — centralizes repository context (code, docs, specs) to improve response quality.
+
+---
+
+## Supported Editors and Surfaces
+
+| Surface | Notes |
+|---------|-------|
+| Visual Studio Code | Full feature support including Agent Mode |
+| JetBrains IDEs | IntelliJ, PyCharm, WebStorm, GoLand, and others |
+| Visual Studio | Windows-native IDE support |
+| Xcode | Includes next-edit predictions |
+| Eclipse | Agent Mode GA July 2025 |
+| Neovim | Plugin-based integration |
+| Zed | Native integration |
+| GitHub.com | Chat, code review, PR summaries, cloud agent |
+| GitHub Mobile | Chat on iOS and Android |
+| GitHub CLI / terminal | Copilot CLI for natural-language shell commands |
+| Windows Terminal Canary | Chat integration |
+
+---
+
+## Pricing Tiers
+
+| Plan | Price | Key Inclusions |
+|------|-------|----------------|
+| **Free** | $0/month | 2,000 completions/month, auto model selection, Copilot CLI |
+| **Pro** | $10/user/month | Unlimited completions, multiple model access, cloud agent, $10 AI credits/month |
+| **Pro+** | $39/user/month | Premium models (Claude Opus, etc.), higher AI credit allowance |
+| **Max** | $100/user/month | Highest individual AI credit allowance, priority access to new models |
+| **Business** | $19/seat/month | Team management, policy controls, monthly AI credit pool |
+| **Enterprise** | $39/seat/month | All Business features, larger credit pool, priority model access, GitHub Enterprise Cloud required |
+
+Free plans also apply to verified students, educators, and qualifying open-source maintainers (Pro-level features).
+
+---
+
+## Tools and Resources
+
+- **Documentation** — [docs.github.com/en/copilot](https://docs.github.com/en/copilot)
+- **Plans and pricing** — [github.com/features/copilot/plans](https://github.com/features/copilot/plans)
+- **REST API for Copilot management** — [docs.github.com/en/rest/copilot](https://docs.github.com/en/rest/copilot) — manage seats, billing, and usage at org/enterprise level.
+- **MCP server catalog** — any MCP-compatible server can extend Copilot's context and tools.
+
+---
+
+## Ecosystem and Integrations
+
+- Integrated natively into GitHub.com, enabling AI assistance directly in pull requests, issues, and discussions without leaving the browser.
+- Works with GitHub Actions for AI-assisted CI pipeline troubleshooting and workflow generation.
+- Enterprise deployments support Bring Your Own Keys (BYOK), allowing organizations to route Copilot through their own LLM provider API keys.
+- Available as a standalone subscription or bundled with GitHub Enterprise Cloud.
+
+---
+
+Get started at [github.com/features/copilot](https://github.com/features/copilot) or explore the full reference at [docs.github.com/en/copilot](https://docs.github.com/en/copilot).

--- a/technologies/github/index.mdx
+++ b/technologies/github/index.mdx
@@ -1,0 +1,81 @@
+---
+title: "GitHub"
+description: "GitHub is the world's leading developer platform for version control and collaboration, hosting over 100 million developers and offering tools for code hosting, CI/CD, security scanning, and AI-assisted development."
+---
+
+# GitHub
+
+GitHub is a cloud-based developer platform built on Git, launched publicly in April 2008 by Tom Preston-Werner, Chris Wanstrath, P.J. Hyett, and Scott Chacon. Acquired by Microsoft in 2018 for $7.5 billion, it has grown into the central hub of open-source software and professional software development, hosting over 100 million developers worldwide. Beyond code hosting, GitHub now offers a full suite of tools spanning CI/CD automation, security analysis, cloud development environments, and AI-powered coding assistance through GitHub Copilot.
+
+| General | |
+|---------|--|
+| **Company** | [GitHub, Inc.](https://github.com) |
+| **Founded** | April 2008 by Tom Preston-Werner, Chris Wanstrath, P.J. Hyett, Scott Chacon |
+| **Acquired by** | Microsoft (October 2018, $7.5B) |
+| **Headquarters** | San Francisco, California, USA |
+| **Website** | [github.com](https://github.com) |
+| **Documentation** | [docs.github.com](https://docs.github.com) |
+| **GitHub** | [github.com/github](https://github.com/github) |
+| **Type** | Developer Platform |
+
+---
+
+## Core Products
+
+### GitHub Repositories and Code Hosting
+The foundation of GitHub: Git-based version control with pull requests, code review workflows, branch protections, and merge strategies. Supports public, private, and internal repositories at any scale.
+
+### GitHub Copilot
+An AI-powered coding assistant providing inline completions, chat, autonomous agent mode, and cloud-based coding agents. Available across VS Code, JetBrains, Xcode, Eclipse, Neovim, and GitHub.com itself.
+
+### GitHub Actions
+A CI/CD and workflow automation platform built into every repository. Write YAML-defined workflows triggered by events (push, PR, schedule) and run them on GitHub-hosted or self-hosted runners.
+
+### GitHub Advanced Security
+Security tools including secret scanning, code scanning (CodeQL static analysis), and Dependabot for dependency vulnerability management. Available on GitHub Enterprise Cloud and as add-ons for Teams.
+
+### GitHub Codespaces
+Cloud-hosted development environments that spin up a full VS Code workspace in seconds, pre-configured from a `devcontainer.json` in the repository.
+
+### GitHub Spark
+A natural-language app builder (public preview) that generates and deploys full-stack web applications from a prompt, integrated with Copilot.
+
+---
+
+## Developer Resources
+
+GitHub's developer ecosystem spans official SDKs, REST and GraphQL APIs, GitHub Apps, OAuth Apps, and Actions marketplace extensions.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Documentation](https://docs.github.com) — complete reference for all GitHub features and APIs
+- [GitHub CLI](https://cli.github.com) — manage repos, issues, and PRs from the terminal
+- [GitHub REST API](https://docs.github.com/en/rest) — programmatic access to all GitHub resources
+- [GitHub GraphQL API](https://docs.github.com/en/graphql) — flexible data queries
+- [GitHub Marketplace](https://github.com/marketplace) — apps and Actions for CI, security, and deployment
+- [GitHub Skills](https://skills.github.com) — interactive learning paths
+
+---
+
+## Key Features
+
+**Integrated AI with Copilot**
+GitHub Copilot is embedded natively across GitHub.com, the CLI, and major IDEs. It supports multi-model selection (OpenAI, Anthropic Claude, Google Gemini), autonomous agent mode, and MCP server integrations.
+
+**Actions-native CI/CD**
+GitHub Actions offers thousands of pre-built actions in the Marketplace, matrix builds, reusable workflows, and first-class integration with every GitHub event.
+
+**Security-first by default**
+Dependabot monitors dependencies for CVEs and auto-opens fix PRs. Secret scanning alerts on accidentally committed credentials. CodeQL catches security vulnerabilities before they ship.
+
+---
+
+## Use Cases
+
+**Open-Source Collaboration**
+GitHub hosts the majority of the world's public open-source projects, providing issue tracking, discussions, wikis, GitHub Pages, and Sponsors for maintainer funding.
+
+**Enterprise Software Delivery**
+GitHub Enterprise Cloud adds SSO, audit logs, compliance controls, IP allowlists, and dedicated support, making it the platform of choice for regulated industries and large engineering organizations.

--- a/technologies/meta/meta-executorch.mdx
+++ b/technologies/meta/meta-executorch.mdx
@@ -1,0 +1,85 @@
+---
+title: "ExecuTorch"
+author: "meta"
+description: "ExecuTorch is Meta's open-source, end-to-end framework for deploying PyTorch models on edge devices including mobile phones, wearables, AR/VR headsets, and microcontrollers, with a 50 KB base runtime and hardware backends for Qualcomm, Apple, MediaTek, Samsung, and ARM."
+---
+
+# ExecuTorch
+
+[**ExecuTorch**](https://github.com/pytorch/executorch) is Meta's production-grade framework for on-device AI inference, allowing PyTorch models to run natively on mobile phones, wearables, embedded systems, and AI PCs without cloud connectivity. Unlike conversion-based pipelines, ExecuTorch exports models directly from `torch.export` to a `.pte` binary format, retaining PyTorch semantics through the entire deployment stack. It reached general availability (v1.0) in October 2025 and is already in production across Meta's Ray-Ban Smart Glasses, Meta Quest headsets, and billions of on-device AI feature interactions on Instagram, WhatsApp, and Messenger.
+
+| General | |
+|---------|--|
+| **GA date** | 18 Oct 2025 (v1.0) |
+| **Developer** | Meta / PyTorch |
+| **Type** | On-Device AI Inference Framework |
+| **License** | BSD License |
+| **GitHub** | [pytorch/executorch](https://github.com/pytorch/executorch) |
+| **Documentation** | [docs.pytorch.org/executorch](https://docs.pytorch.org/executorch/stable/) |
+
+---
+
+## Core Features
+
+- **PyTorch-native export** — models go from `torch.export` directly to `.pte` format with no ONNX or TFLite conversion step.
+- **50 KB base runtime** — minimal core footprint suitable for microcontrollers and embedded targets.
+- **Ahead-of-time compilation** — models compiled offline to `.pte` binaries, reducing on-device startup overhead.
+- **Single-line backend switching** — swap hardware accelerators (CPU, NPU, GPU) without rewriting model code.
+- **Quantization tooling** — INT8, INT4 (per-block), QAT+LoRA (QLoRA), and SpinQuant quantization via integrated PyTorch tools.
+- **Selective operator builds** — include only operators the model uses, minimizing binary size.
+- **Multimodal support** — composable backbone for LLMs, vision-language models, image segmentation, depth estimation, OCR, ASR, and object detection.
+- **Hugging Face Optimum-ExecuTorch** — over 80% of the most-downloaded edge-friendly models on Hugging Face run on ExecuTorch out of the box.
+
+---
+
+## Supported Hardware Backends
+
+| Backend | Target | Status |
+|---------|--------|--------|
+| XNNPACK + Arm KleidiAI | CPU (Android, iOS, Linux, AI PCs) | Stable |
+| Apple Core ML | Apple silicon (iOS, macOS) | Stable |
+| Qualcomm AI Engine / Hexagon NPU | Android (Qualcomm SoCs) | Stable |
+| Arm Ethos-U NPU | Embedded / MCU | Stable |
+| Vulkan GPU | Cross-platform GPU (Android, Linux) | Stable |
+| Apple MPS (Metal Performance Shaders) | iOS / macOS GPU | Alpha |
+| MediaTek NPU | Android (MediaTek SoCs) | Beta |
+| Samsung Exynos NPU | Android (Samsung SoCs) | Alpha |
+| Intel OpenVINO | AI PCs (Windows / Linux x86) | Alpha |
+| CUDA | Linux / Windows GPU | Experimental |
+
+Hardware partners include Apple, Arm, Cadence, Intel, MediaTek, NXP Semiconductors, Qualcomm, and Samsung.
+
+---
+
+## Performance (Llama 3.2 1B Quantized)
+
+| Device | Decode Speed | Prefill Speed |
+|--------|-------------|---------------|
+| Samsung Galaxy S24+ | >40 tokens/s | >350 tokens/s |
+| OnePlus 12 | 50.2 tokens/s | 260 tokens/s |
+
+Quantization reduces model size by ~52% (2.3 GiB to 1.1 GiB) and peak runtime memory by ~39%, with 2.5x average decode latency improvement over BF16 baseline.
+
+---
+
+## Tools and Resources
+
+- **GitHub** — [github.com/pytorch/executorch](https://github.com/pytorch/executorch) — source code, model export scripts, and backend integrations.
+- **Documentation** — [docs.pytorch.org/executorch/stable](https://docs.pytorch.org/executorch/stable/) — installation, export workflow, and backend guides.
+- **PyPI** — `pip install executorch` — Python package for model export and tooling.
+- **Llama export script** — `export_llm` command in the repo for exporting Llama variants to `.pte` format.
+- **PyTorch blog** — [pytorch.org/blog/introducing-executorch-1-0](https://pytorch.org/blog/introducing-executorch-1-0/) — GA announcement with performance benchmarks.
+
+---
+
+## Ecosystem and Integrations
+
+- Powers on-device AI in **Meta Ray-Ban Smart Glasses** (live translation, visual captions, menu translation) and **Oakley Meta Vanguard glasses** (athletic performance insights).
+- Runs scene understanding, depth estimation, hand tracking, and persistent room memory on **Meta Quest 3 / Quest 3S**.
+- Llama 3.2 1B and 3B models were co-developed with Qualcomm and MediaTek for optimized Snapdragon deployment via ExecuTorch.
+- Backend available in **Hugging Face Optimum-ExecuTorch** for direct integration with the Hugging Face model hub.
+- Complements **PyTorch Mobile** for teams already in the PyTorch ecosystem, offering a significantly smaller runtime and better edge-hardware coverage.
+
+---
+
+Get started by cloning [github.com/pytorch/executorch](https://github.com/pytorch/executorch) and following the [quickstart guide](https://docs.pytorch.org/executorch/stable/getting-started.html), or install via `pip install executorch` for model export tooling.

--- a/technologies/qualcomm/index.mdx
+++ b/technologies/qualcomm/index.mdx
@@ -1,0 +1,74 @@
+---
+title: "Qualcomm"
+description: "Qualcomm is a fabless semiconductor company and wireless technology leader, designing Snapdragon SoCs that power AI experiences on over 4.3 billion devices across mobile, PC, automotive, and IoT applications."
+---
+
+# Qualcomm
+
+Qualcomm was founded in July 1985 in San Diego by seven engineers, including Irwin Jacobs and Andrew Viterbi, as a wireless communications research firm. Over four decades it has become the defining company in mobile silicon, designing the Snapdragon family of system-on-chips that sit inside the majority of the world's Android smartphones, Copilot+ PCs, XR headsets, and connected automotive systems. Qualcomm operates as a fabless semiconductor company, focusing on chip design and its vast patent portfolio covering CDMA, 3G, 4G LTE, and 5G NR technologies.
+
+| General | |
+|---------|--|
+| **Company** | [Qualcomm Incorporated](https://www.qualcomm.com) |
+| **Founded** | July 1, 1985 by Irwin Jacobs, Andrew Viterbi, and five colleagues |
+| **Headquarters** | San Diego, California, USA |
+| **Website** | [qualcomm.com](https://www.qualcomm.com) |
+| **Documentation** | [Developer Portal](https://www.qualcomm.com/developer) |
+| **GitHub** | [github.com/qualcomm](https://github.com/qualcomm) |
+| **Type** | Semiconductor and Wireless Technology |
+
+---
+
+## Core Products
+
+### Snapdragon SoC Platform
+Snapdragon is Qualcomm's flagship system-on-chip brand integrating CPU, GPU, NPU (Hexagon), modem, and connectivity in a single package. Snapdragon chips power mobile phones, Windows laptops (Copilot+ PC), AR/VR headsets, automotive cockpits, and IoT devices.
+
+### Dragonwing
+Qualcomm's commercial and industrial product line, built on Snapdragon silicon, targeting industrial IoT, robotics, and smart edge deployments.
+
+### Qualcomm AI Hub
+A developer platform at [aihub.qualcomm.com](https://aihub.qualcomm.com) offering 175+ pre-optimized AI models, a cloud-based profiling workbench for testing across 50+ device types, and sample applications. Developers can optimize, benchmark, and deploy models on Snapdragon hardware without owning devices.
+
+### Connectivity and RF
+Qualcomm designs Wi-Fi, Bluetooth, and 5G modem products used across consumer electronics, automotive, and infrastructure.
+
+---
+
+## Developer Resources
+
+Qualcomm provides a full developer toolkit for building AI-accelerated applications on Snapdragon hardware, from low-level NPU SDKs to cloud-hosted device profiling.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Qualcomm AI Hub](https://aihub.qualcomm.com) — pre-optimized models, cloud profiling, and deployment tools
+- [AI Hub Models GitHub](https://github.com/qualcomm/ai-hub-models) — open-source model repository (BSD-3-Clause)
+- [Developer Portal](https://www.qualcomm.com/developer) — SDKs, documentation, and dev kits
+- [GitHub](https://github.com/qualcomm) — open-source SDKs and tools
+- [Developer Discord](https://discord.com/invite/qualcommdevelopernetwork) — community support
+- [YouTube Channel](https://www.youtube.com/qualcommdev) — tutorials and product walkthroughs
+
+---
+
+## Key Features
+
+**Heterogeneous AI Engine**
+Qualcomm's AI Engine combines the Hexagon NPU, Adreno GPU, and Oryon/Kryo CPU into a coordinated compute pipeline. This lets applications shift workloads to the most efficient processor at runtime, achieving high performance at low power.
+
+**On-Device AI at Scale**
+Qualcomm AI Engine ships in over 4.3 billion devices. The Hexagon NPU supports FP32, FP16, INT16, and INT8 precision, enabling deployment of large language models and image generation on mobile hardware without cloud dependency.
+
+**Broad SDK Ecosystem**
+Developer tools include the AI Engine Direct SDK (QNN), the AI Model Efficiency Toolkit (AIMET) for quantization and pruning, the Snapdragon Neural Processing Engine (SNPE), and an ONNX Runtime execution provider plugin.
+
+---
+
+## Use Cases
+
+**On-Device Generative AI**
+Run quantized LLMs (Llama, Mistral, Qwen) and image-generation models locally on Snapdragon phones and laptops. AI Hub provides ready-to-deploy `.pte` and optimized model artifacts for direct integration.
+
+**Mobile and Embedded Vision**
+Object detection, depth estimation, scene segmentation, and OCR run at real-time framerates on the Hexagon NPU with Qualcomm's pre-optimized model zoo.

--- a/technologies/qualcomm/qualcomm-snapdragon.mdx
+++ b/technologies/qualcomm/qualcomm-snapdragon.mdx
@@ -1,0 +1,67 @@
+---
+title: "Snapdragon"
+author: "qualcomm"
+description: "Snapdragon is Qualcomm's flagship system-on-chip platform integrating CPU, GPU, Hexagon NPU, modem, and connectivity for mobile phones, Windows laptops, AR/VR headsets, and automotive systems, with NPU performance reaching 100 TOPS on the Snapdragon 8 Elite."
+---
+
+# Snapdragon
+
+[**Snapdragon**](https://www.qualcomm.com/snapdragon) is Qualcomm's brand for its system-on-chip (SoC) family, combining processing, graphics, neural processing, modem, and radio connectivity on a single piece of silicon. From the Snapdragon 8 Elite powering flagship Android smartphones to the Snapdragon X Elite running Windows Copilot+ PCs, the platform targets the full spectrum of connected devices. Snapdragon is the primary hardware platform for on-device AI in consumer electronics, with the Hexagon NPU achieving up to 100 TOPS on the latest generation.
+
+| General | |
+|---------|--|
+| **Developer** | Qualcomm |
+| **Type** | System-on-Chip Platform |
+| **License** | Proprietary (silicon); developer tools include open-source components |
+| **GitHub** | [qualcomm/ai-hub-models](https://github.com/qualcomm/ai-hub-models) |
+| **Documentation** | [Qualcomm AI Hub Docs](https://workbench.aihub.qualcomm.com/docs/hub/index.html) |
+| **AI Hub** | [aihub.qualcomm.com](https://aihub.qualcomm.com) |
+
+---
+
+## Core Features
+
+- **Hexagon NPU** — dedicated neural processing unit optimized for AI inference; achieves 40 TOPS (8 Gen 3) to 100 TOPS (8 Elite); ranked #1 on MLPerf Inference v4.0 mobile benchmark.
+- **Heterogeneous AI Engine** — workloads dynamically distributed across Hexagon NPU, Adreno GPU, and Oryon/Kryo CPU for optimal power efficiency.
+- **Qualcomm AI Hub** — cloud platform with 175+ pre-optimized models and remote profiling on 50+ real Snapdragon devices; install with `pip install qai_hub_models`.
+- **Multi-precision support** — FP32, FP16, INT16, and INT8 inference; enables quantized LLM deployment on mobile hardware.
+- **On-device LLM execution** — validated with Llama, Mistral, Qwen3, IBM Granite, and Stable Diffusion variants via AI Hub.
+- **Sensing Hub** — ultra-low-power always-on processor for continuous sensor monitoring without waking the main cores.
+
+---
+
+## Snapdragon Platform Variants
+
+| Variant | Segment | NPU Performance | Notable Devices |
+|---------|---------|----------------|-----------------|
+| **Snapdragon 8 Elite** | Flagship mobile (2024-2025) | 100 TOPS | Samsung Galaxy S25 series |
+| **Snapdragon 8 Gen 3** | Flagship mobile (2023-2024) | ~40 TOPS | Samsung Galaxy S24 series |
+| **Snapdragon X Elite** | Windows laptops / Copilot+ PC | 45 TOPS | Microsoft Surface Laptop |
+| **Snapdragon X2 Elite** | Windows laptops (2025) | 80 TOPS | Next-gen Copilot+ PCs |
+| **Snapdragon AR2** | AR glasses | Ultra-low power | Various XR wearables |
+
+---
+
+## Tools and Resources
+
+- **Qualcomm AI Hub** — [aihub.qualcomm.com](https://aihub.qualcomm.com) — browse pre-optimized models, run cloud profiling sessions, and download deployment artifacts.
+- **AI Hub Models (GitHub)** — [github.com/qualcomm/ai-hub-models](https://github.com/qualcomm/ai-hub-models) — open-source Python library (BSD-3-Clause) with 200+ model recipes.
+- **AI Engine Direct SDK (QNN)** — low-level SDK for building applications directly targeting the Hexagon NPU.
+- **AI Model Efficiency Toolkit (AIMET)** — quantization, pruning, and compression tools for edge-friendly model preparation.
+- **Snapdragon Neural Processing Engine (SNPE)** — runtime that converts ONNX and TensorFlow models to Snapdragon-native format.
+- **Qualcomm Device Cloud** — remote access to physical Snapdragon hardware for testing without owning devices.
+- **ONNX Runtime Execution Provider** — plugin for running ONNX models with Hexagon NPU acceleration.
+- **Developer Discord** — [discord.com/invite/qualcommdevelopernetwork](https://discord.com/invite/qualcommdevelopernetwork).
+
+---
+
+## Ecosystem and Integrations
+
+- Verified integrations with Amazon SageMaker, Hugging Face, Roboflow, Dataloop, EyePop.ai, and NOTA AI for model preparation and deployment.
+- ExecuTorch (Meta/PyTorch) includes a stable Qualcomm AI Engine backend for deploying PyTorch models directly to the Hexagon NPU.
+- Llama 3.2 1B and 3B models from Meta were co-optimized for Snapdragon via QAT+LoRA quantization, achieving over 350 tokens/s prefill on Galaxy S24+.
+- Copilot+ PCs built on Snapdragon X Elite are Windows-native AI development targets, with NPU exposure via DirectML and QNN.
+
+---
+
+Start building with the [Qualcomm AI Hub quickstart](https://aihub.qualcomm.com) or clone the [ai-hub-models repository](https://github.com/qualcomm/ai-hub-models) and run `pip install qai_hub_models` to access the full model library.

--- a/technologies/samsung/index.mdx
+++ b/technologies/samsung/index.mdx
@@ -1,0 +1,78 @@
+---
+title: "Samsung"
+description: "Samsung Electronics is a global leader in consumer electronics, mobile devices, and semiconductors, offering developers a broad platform including Galaxy smartphones, Knox security, SmartThings IoT, and Galaxy AI on-device inference tools."
+---
+
+# Samsung
+
+Samsung Electronics Co., Ltd. was founded in January 1969 as a spin-off from the broader Samsung Group conglomerate. Headquartered in Suwon, South Korea, it has grown into one of the world's largest technology companies by revenue, producing everything from NAND flash memory and OLED displays to Galaxy smartphones and home appliances. For developers, Samsung is most relevant as the maker of the Galaxy device ecosystem, the Knox enterprise security platform, the SmartThings IoT platform, and the on-device AI infrastructure powering Galaxy AI across its latest flagship hardware.
+
+| General | |
+|---------|--|
+| **Company** | [Samsung Electronics Co., Ltd.](https://www.samsung.com) |
+| **Founded** | January 13, 1969 |
+| **Headquarters** | Suwon, South Korea |
+| **Website** | [samsung.com](https://www.samsung.com) |
+| **Documentation** | [developer.samsung.com](https://developer.samsung.com) |
+| **GitHub** | [github.com/samsung](https://github.com/samsung) |
+| **Type** | Consumer Electronics and Semiconductor Manufacturer |
+
+---
+
+## Core Products
+
+### Galaxy Mobile (Smartphones and Tablets)
+The Galaxy S, Z Fold/Flip, and A series cover flagship, foldable, and mid-range Android devices. Galaxy S-series flagships run the Snapdragon 8 Elite (custom Samsung variant) and power the company's Galaxy AI on-device inference features.
+
+### Knox Security Platform
+Knox is Samsung's enterprise mobile security framework, providing hardware-backed secure enclaves (Knox Vault), app containerization, and device management APIs. Knox Vault is also the protected enclave for Galaxy AI's Personal Data Engine, keeping on-device AI data encrypted and local.
+
+### SmartThings
+An IoT and smart home platform connecting Samsung devices and third-party products under a unified app and developer SDK. SmartThings supports automations, device control APIs, and Matter/Thread connectivity standards.
+
+### Bixby
+Samsung's voice AI platform, integrated across Galaxy devices for device control, accessibility, and routines. The Bixby ecosystem offers developer extensions for third-party app integration.
+
+### Tizen
+Samsung's Linux-based OS used in Smart TVs, Galaxy Watches, and IoT appliances. Tizen apps are built with the Tizen SDK and distributed through the Samsung Smart TV app store or wearable ecosystem.
+
+---
+
+## Developer Resources
+
+Samsung offers SDKs covering mobile AI, health sensors, enterprise security, IoT, wearables, and in-app purchases, along with a Remote Test Lab for cloud-based Galaxy device testing.
+
+<TechTutorials/>
+
+### Helpful Links
+
+- [Samsung Developer Portal](https://developer.samsung.com) — SDKs, documentation, Code Labs, and community forums
+- [Galaxy On-Device AI Partner Portal](https://aisdk.developer.samsung.com/overview) — Samsung AI SDK access (application-based)
+- [Knox Documentation](https://docs.samsungknox.com) — enterprise security APIs and Galaxy AI data policies
+- [GitHub (Samsung)](https://github.com/samsung) — 181+ open-source repositories
+- [GitHub (Samsung Developers)](https://github.com/samsungdevelopers) — developer-focused tooling
+- [Remote Test Lab](https://developer.samsung.com) — test on real Galaxy hardware without owning devices
+- [Samsung Developer Conference (SDC24)](https://developer.samsung.com/conference/sdc24) — on-demand sessions covering Galaxy AI, Knox AI, and SmartThings
+
+---
+
+## Key Features
+
+**On-Device AI with Galaxy AI**
+Galaxy S-series flagships run AI workloads locally on the Snapdragon Hexagon NPU. Features like Generative Edit, live call transcription, and 20-language translation process data on-device, protected by Knox Vault. The Personal Data Engine analyzes user data locally without cloud upload.
+
+**Galaxy Ecosystem Breadth**
+Samsung ships across phones, tablets, foldables, smartwatches, rings, TVs, and home appliances, giving developers a single SDK surface to reach a large installed base of devices spanning form factors.
+
+**Enterprise-Grade Security**
+Knox is standard on all Galaxy business devices, offering MDM/EMM integration, remote lock/wipe, app separation, and hardware-backed attestation that meets government and financial-sector compliance requirements.
+
+---
+
+## Use Cases
+
+**On-Device Generative AI Applications**
+The Galaxy On-Device AI Partner Portal provides access to the Samsung AI SDK for building applications that run inference locally on the Hexagon NPU, targeting privacy-sensitive or offline-capable AI features.
+
+**Enterprise Mobile Deployments**
+Knox APIs enable IT teams to configure, secure, and remotely manage Galaxy fleets across regulated industries including healthcare, finance, and government.

--- a/technologies/samsung/samsung-galaxy-s25-ultra.mdx
+++ b/technologies/samsung/samsung-galaxy-s25-ultra.mdx
@@ -1,0 +1,75 @@
+---
+title: "Samsung Galaxy S25 Ultra"
+author: "samsung"
+description: "Samsung Galaxy S25 Ultra is a 2025 flagship Android smartphone powered by Qualcomm's Snapdragon 8 Elite for Galaxy, featuring a Hexagon NPU for on-device Galaxy AI, 6.9-inch AMOLED display, integrated S Pen, and 12-16 GB RAM for developer and AI-focused workloads."
+---
+
+# Samsung Galaxy S25 Ultra
+
+[**Samsung Galaxy S25 Ultra**](https://www.samsung.com/us/smartphones/galaxy-s25-ultra/) is Samsung's 2025 flagship smartphone, announced January 22, 2025 and released February 3, 2025. It is powered by the Qualcomm Snapdragon 8 Elite for Galaxy, a custom 3 nm variant of Qualcomm's top mobile SoC. The S25 Ultra is the primary hardware target for the ExecuTorch hackathon and represents Samsung's most capable on-device AI platform, with the Hexagon NPU enabling features that previously required cloud processing to run entirely on the device.
+
+| General | |
+|---------|--|
+| **Release date** | 3 Feb 2025 |
+| **Developer** | Samsung Electronics |
+| **Type** | Flagship Android Smartphone |
+| **License** | Commercial device; developer tools available |
+| **Documentation** | [developer.samsung.com](https://developer.samsung.com) |
+| **OS** | Android 15, One UI 8 (7 major Android upgrades promised) |
+
+---
+
+## Core Features
+
+- **Snapdragon 8 Elite for Galaxy** — Qualcomm's 3 nm SoC with Oryon V2 CPU cores (up to 4.47 GHz) and Hexagon NPU; 40% faster AI task handling and 45% better performance-per-watt vs. Snapdragon 8 Gen 3 (S24 Ultra).
+- **On-device Galaxy AI** — Generative Edit, live call transcription, 20-language translation, and Writing Assist run locally on the Hexagon NPU, not in the cloud.
+- **Personal Data Engine** — on-device engine that analyzes Samsung native-app data to personalize AI features; all data stays local, encrypted in Knox Vault.
+- **Knox KEEP** — hardware-backed encrypted storage environments for AI data per application.
+- **Google Gemini integration** — Gemini handles cross-app agentic commands (Circle to Search, multi-step actions) via the side button.
+- **S Pen** — built-in stylus with S Pen Remote SDK for developers to build custom button-interaction features.
+- **6.9-inch Dynamic LTPO AMOLED 2X** — 120Hz, 1440 x 3120 resolution, 2600 nits peak, Gorilla Armor 2 glass.
+- **12 GB / 16 GB LPDDR5X RAM** — with 256 GB, 512 GB, or 1 TB UFS 4.0 storage.
+- **USB-C 3.2 Gen 2** — with DisplayPort 1.2 for Samsung DeX desktop mode.
+
+---
+
+## Galaxy AI Features
+
+| Feature | On-Device or Cloud | Description |
+|---------|-------------------|-------------|
+| Now Brief | On-device | Proactive personalized daily briefing on lock screen |
+| Now Bar | On-device | Always-visible status for live tasks and ongoing activities |
+| Generative Edit | On-device | AI photo editing (previously cloud-only on S24) |
+| Audio Eraser | On-device | Remove specific ambient sounds from recorded video |
+| Circle to Search | Google cloud | Detect phone numbers, emails, URLs in video/audio |
+| Cross App Actions | Gemini cloud | Multi-step tasks via one natural-language command |
+| Portrait Studio | Cloud | AI portrait modes (Sketch, Watercolor, Cartoon, 3D) |
+| Call Transcript | On-device | Live call transcription with automatic note formatting |
+| 20-language Translation | On-device | Real-time spoken language translation |
+| Writing Assist | On-device | Summarization, rewriting, and auto-formatting |
+| ProScaler | On-device | 40% AI-enhanced display upscaling |
+| Multimodal Settings | On-device | Natural-language device settings control |
+
+---
+
+## Tools and Resources
+
+- **Samsung Developer Portal** — [developer.samsung.com](https://developer.samsung.com) — SDKs, Code Labs, Remote Test Lab, and community support.
+- **Galaxy On-Device AI Partner Portal** — [aisdk.developer.samsung.com](https://aisdk.developer.samsung.com/overview) — access to the Samsung AI SDK for building on-device AI features (application-based).
+- **S Pen Remote SDK** — build custom interactions triggered by S Pen button gestures.
+- **Remote Test Lab** — test your app on real Galaxy S25 Ultra hardware without owning a device.
+- **Knox Documentation** — [docs.samsungknox.com](https://docs.samsungknox.com) — enterprise security APIs and Galaxy AI data processing policies.
+- **SDC24 on-demand sessions** — [developer.samsung.com/conference/sdc24](https://developer.samsung.com/conference/sdc24) — Galaxy AI, Knox AI, and on-device inference deep dives.
+
+---
+
+## Ecosystem and Integrations
+
+- ExecuTorch (Meta/PyTorch) includes an alpha Samsung Exynos NPU backend; Snapdragon 8 Elite is supported via the stable Qualcomm AI Engine backend.
+- Llama 3.2 1B and 3B quantized models achieve over 40 tokens/s decode and over 350 tokens/s prefill on the Galaxy S24+ (Snapdragon 8 Gen 3); the S25 Ultra's Snapdragon 8 Elite delivers further improvements.
+- Google Gemini is the primary agentic AI runtime on Galaxy S25 Ultra, enabling cross-app automation and visual search via Circle to Search.
+- Samsung DeX turns the S25 Ultra into a desktop workstation when connected to a monitor via USB-C, useful for developer productivity.
+
+---
+
+Start building for Galaxy S25 Ultra at [developer.samsung.com](https://developer.samsung.com) or request Samsung AI SDK access through the [Galaxy On-Device AI Partner Portal](https://aisdk.developer.samsung.com/overview).


### PR DESCRIPTION
## Summary

- **Qualcomm**: new company index + `qualcomm-snapdragon` product page covering Snapdragon SoC family, Hexagon NPU, and Qualcomm AI Hub
- **Meta**: `meta-executorch` product page covering ExecuTorch v1.0 on-device inference framework, supported backends, Llama integration, and performance benchmarks (Meta company index already existed)
- **GitHub**: new company index + `github-copilot` product page covering Copilot features, pricing tiers, supported IDEs, and API access
- **Samsung**: new company index + `samsung-galaxy-s25-ultra` product page covering Snapdragon 8 Elite, Galaxy AI on-device/cloud feature breakdown, and developer SDK resources

## Test plan

- [ ] Verify all 7 MDX files have valid frontmatter (`title`, `description`, `author` on product pages)
- [ ] Confirm no em dashes, placeholder text, or invented facts
- [ ] Check that company index pages include `<TechTutorials/>` in the Developer Resources section
- [ ] Spot-check URLs: qualcomm.com, aihub.qualcomm.com, pytorch.org/executorch, github.com/features/copilot, developer.samsung.com