### PR TITLE
Add AI Hackathon Success Stories Part 3: SentinelIQ, RSoft, Brockn Code

### DIFF
--- a/blog/en/lablab-hackathon-success-stories-part-3.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-3.mdx
@@ -1,0 +1,74 @@
+---
+title: "AI Hackathon Success Stories (Part 3): Three Builders Who Bet on the Gap and Won"
+description: "AI hackathon success stories: three builders who made the decisive bet nobody else was willing to make — SentinelIQ, RSoft, and Brockn Code."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/3801a09d-3a8f-49ed-15ea-30145e734200/public"
+authorUsername: "stevekimoi"
+---
+
+Three builders. Three different rooms, three different hackathons, three different problems. What connects them is not the stack they used or the category they won. It is the moment inside the event when most people would have held course — and they didn't.
+
+## Jamsheer Jabbar and Amal Jose: The Pivot That Won It
+
+Jamsheer Jabbar had spent years inside trading fintechs watching the same failure repeat. Mountains of data, scattered across CRMs, ERPs, compliance tools, and spreadsheets, with no way to see it all together in real time with intelligence layered on top. Engineers built dashboards that were stale before launch. When something went wrong, the answer was buried across five platforms, and by the time anyone connected the dots, the window to act had closed.
+
+At the Deriv AI Hackathon Dubai, hosted by the global trading platform that lived inside this exact problem every day, Jamsheer and his teammate Amal Jose set out to fix it. SentinelIQ is a dual-agent platform that connects data across six business domains — clients, finance, partners, operations, compliance, and competition — and turns it into live insights, risk scores, and executive-ready recommendations without requiring an engineer to run it.
+
+The first agent, the Sentinel Autonomous Scanner, does not wait to be asked. It generates its own audit missions, scores risks on a zero to one hundred scale based on dollar exposure, velocity, and trend severity, and correlates patterns across all six domains simultaneously. The second agent handles natural language queries: anyone in the business can ask a question in plain English and receive intent classification, domain detection, SQL generation, and insight delivery in return. Results push to Slack in real time. After every scan, the platform produces an Executive Intelligence Brief — not a data dump, but a decision document.
+
+Then, midway through the event, they almost scrapped it.
+
+With four hours left on the clock, it became clear the judges were looking for something beyond their original scope. Jamsheer and Amal made the call to rebuild. They stripped the original approach and added an entirely new autonomous layer: an AI-driven research and insight generation engine that could operate without human prompting. It was the kind of decision that looks reckless from the outside. That last-minute pivot won them the prize.
+
+What happened next is rarer. Inspired by SentinelIQ's potential, Jamsheer proposed a similar agentic approach for automated insight generation inside his organisation. It is now in production.
+
+His advice: "Break barriers about yourself. You are never limited to what you do right now. Don't stop fantasizing and manifesting — because what you imagine is what you'll become, if you're willing to do the work."
+
+[SentinelIQ](https://lablab.ai/ai-hackathons/deriv-ai-hackathon-dubai)
+
+## Ricardo Pari: Scrapping a Week of Work Was the Best Call
+
+One week before the deadline for the SURGE × OpenClaw Hackathon, Ricardo Pari and his team looked at what they had built — an AI agent that buys concert tickets — and made a decision.
+
+They threw it out.
+
+The insight that replaced it: AI agents are starting to act autonomously, but they have no real financial infrastructure. No way to hold value, get credit, or settle payments without a human in the loop. The banking rail the agent economy needed did not exist. Ricardo's team built it.
+
+RSoft ClawBank is an agentic bank. Agent identity, credit scoring, and USDC settlement, built on OpenClaw, x402, LangChain, and Circle. Agents can request and receive credit and settle payments autonomously. It won first place.
+
+RSoft did not stop there. At the Agentic Commerce on Arc Hackathon, Ricardo returned with RSoft Agentic Bank — an evolved version of the same infrastructure. He submitted with thirty seconds to spare. It won first place again.
+
+The production codebase has since migrated to LangGraph, Supabase, and AWS, and is heading to Base mainnet. Ricardo earned a seat in the Surge accelerator and a Builder Spotlight at ARCTALKS with Circle.
+
+Two wins, one pivot, one week of scrapped work. Ricardo's advice for future participants: "Don't be afraid to pivot. We threw out a week of work and it was the best call we made. Just build and ship — you learn more in one weekend than in months."
+
+[RSoft Agentic Bank](https://lablab.ai/ai-hackathons/agentic-commerce-on-arc/rsoft-latam/rsoft-agentic-bank)
+
+## Rohan Jadhav: The Win Nobody Told Him About
+
+Rohan Jadhav, Yash Deshpande, and Rushi Patil were all twenty-one years old and in the final year of their Computer Science degree when they entered the Qubic Hack the Future Hackathon. They were building Brockn Code — a student-led startup — alongside their studies, and they wanted to test their skills on a global stage.
+
+Coming from a Tier 3 college in India, Rohan had already participated in more than ten hackathons. He knew what it meant to compete against teams with more resources, more experience, and more institutional backing. The bet he made was a simpler one: that determination, teamwork, and solid execution could compete anyway.
+
+They built the Qubic Live Whale and Token Analytics Dashboard — a platform providing real-time insights into whale activity, token movements, and ecosystem trends within the Qubic network, making complex blockchain data accessible and actionable for everyday users.
+
+They finished. The hackathon ended. The winners were announced.
+
+Rohan did not know he had won.
+
+Three or four days after the official announcement, a teammate called him late at night with the news. Third place, on an international stage. Rohan describes it as one of the most-told stories from the entire experience.
+
+The win validated what Brockn Code was built on: the belief that innovation does not depend on the name of the college or the size of the city. It begins with curiosity, execution, and the willingness to learn through building.
+
+"Start with a real problem. Focus on execution rather than perfection. Trust your team, communicate clearly, and don't be afraid to learn as you go. And most importantly: participate. Every hackathon teaches you something valuable, whether you win or not."
+
+[Brockn Code](https://lablab.ai/ai-hackathons/qubic-hack-the-future/brockn-code/qubic-live-whale-and-token-analytics-dashboard)
+
+{/* SLOT: Carolina Alvarez-Areces Miranda — LUNA AI story goes here once her full write-up and video arrive */}
+
+## What These Three Share
+
+None of them won by executing the safe version of their idea. Jamsheer and Amal rebuilt their submission with four hours left. Ricardo threw away a full week of work and built something entirely different. Rohan bet that a student team from a Tier 3 college in India could compete on a global stage — and found out they had won days after everyone else did.
+
+The pattern is not coincidental. [AI hackathons](https://lablab.ai/ai-hackathons) compress the validation cycle in a way that almost nothing else does. You build, you demo, you get direct feedback from people with real expertise. What they found out, in different rooms and different cities, is that the right move under pressure is rarely the one that feels safe.
+
+If you are building something, the next lablab event may be the clearest test of whether it works. Browse [upcoming AI hackathons](https://lablab.ai/events) and find your room.

--- a/blog/en/lablab-hackathon-success-stories-part-3.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-3.mdx
@@ -1,19 +1,19 @@
 ---
 title: "AI Hackathon Success Stories (Part 3): Three Builders Who Bet on the Gap and Won"
-description: "AI hackathon success stories: three builders who made the decisive bet nobody else was willing to make — SentinelIQ, RSoft, and Brockn Code."
+description: "AI hackathon success stories: three builders who made the decisive bet nobody else was willing to make: SentinelIQ, RSoft, and Brockn Code."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/3801a09d-3a8f-49ed-15ea-30145e734200/public"
 authorUsername: "stevekimoi"
 ---
 
-Three builders. Three different rooms, three different hackathons, three different problems. What connects them is not the stack they used or the category they won. It is the moment inside the event when most people would have held course — and they didn't.
+Three builders. Three different rooms, three different hackathons, three different problems. What connects them is not the stack they used or the category they won. It is the moment inside the event when most people would have held course. They didn't.
 
 ## Jamsheer Jabbar and Amal Jose: The Pivot That Won It
 
 Jamsheer Jabbar had spent years inside trading fintechs watching the same failure repeat. Mountains of data, scattered across CRMs, ERPs, compliance tools, and spreadsheets, with no way to see it all together in real time with intelligence layered on top. Engineers built dashboards that were stale before launch. When something went wrong, the answer was buried across five platforms, and by the time anyone connected the dots, the window to act had closed.
 
-At the Deriv AI Hackathon Dubai, hosted by the global trading platform that lived inside this exact problem every day, Jamsheer and his teammate Amal Jose set out to fix it. SentinelIQ is a dual-agent platform that connects data across six business domains — clients, finance, partners, operations, compliance, and competition — and turns it into live insights, risk scores, and executive-ready recommendations without requiring an engineer to run it.
+At the Deriv AI Hackathon Dubai, hosted by the global trading platform that lived inside this exact problem every day, Jamsheer and his teammate Amal Jose set out to fix it. SentinelIQ is a dual-agent platform that connects data across six business domains: clients, finance, partners, operations, compliance, and competition. It turns that data into live insights, risk scores, and executive-ready recommendations without requiring an engineer to run it.
 
-The first agent, the Sentinel Autonomous Scanner, does not wait to be asked. It generates its own audit missions, scores risks on a zero to one hundred scale based on dollar exposure, velocity, and trend severity, and correlates patterns across all six domains simultaneously. The second agent handles natural language queries: anyone in the business can ask a question in plain English and receive intent classification, domain detection, SQL generation, and insight delivery in return. Results push to Slack in real time. After every scan, the platform produces an Executive Intelligence Brief — not a data dump, but a decision document.
+The first agent, the Sentinel Autonomous Scanner, does not wait to be asked. It generates its own audit missions, scores risks on a zero to one hundred scale based on dollar exposure, velocity, and trend severity, and correlates patterns across all six domains simultaneously. The second agent handles natural language queries: anyone in the business can ask a question in plain English and receive intent classification, domain detection, SQL generation, and insight delivery in return. Results push to Slack in real time. After every scan, the platform produces an Executive Intelligence Brief: not a data dump, but a decision document.
 
 Then, midway through the event, they almost scrapped it.
 
@@ -21,13 +21,13 @@ With four hours left on the clock, it became clear the judges were looking for s
 
 What happened next is rarer. Inspired by SentinelIQ's potential, Jamsheer proposed a similar agentic approach for automated insight generation inside his organisation. It is now in production.
 
-His advice: "Break barriers about yourself. You are never limited to what you do right now. Don't stop fantasizing and manifesting — because what you imagine is what you'll become, if you're willing to do the work."
+His advice: "Break barriers about yourself. You are never limited to what you do right now. Don't stop fantasizing and manifesting, because what you imagine is what you'll become, if you're willing to do the work."
 
-[SentinelIQ](https://lablab.ai/ai-hackathons/deriv-ai-hackathon-dubai)
+[SentinelIQ](https://lablab.ai/ai-hackathons/deriv-ai-talent-sprint/starfleet/sentineliq-autonomous-enterprise-intelligence)
 
 ## Ricardo Pari: Scrapping a Week of Work Was the Best Call
 
-One week before the deadline for the SURGE × OpenClaw Hackathon, Ricardo Pari and his team looked at what they had built — an AI agent that buys concert tickets — and made a decision.
+One week before the deadline for the SURGE × OpenClaw Hackathon, Ricardo Pari and his team looked at what they had built: an AI agent that buys concert tickets. They made a decision.
 
 They threw it out.
 
@@ -35,7 +35,7 @@ The insight that replaced it: AI agents are starting to act autonomously, but th
 
 RSoft ClawBank is an agentic bank. Agent identity, credit scoring, and USDC settlement, built on OpenClaw, x402, LangChain, and Circle. Agents can request and receive credit and settle payments autonomously. It won first place.
 
-RSoft did not stop there. At the Agentic Commerce on Arc Hackathon, Ricardo returned with RSoft Agentic Bank — an evolved version of the same infrastructure. He submitted with thirty seconds to spare. It won first place again.
+RSoft did not stop there. At the Agentic Commerce on Arc Hackathon, Ricardo returned with RSoft Agentic Bank, an evolved version of the same infrastructure. He submitted with thirty seconds to spare. It won first place again.
 
 The production codebase has since migrated to LangGraph, Supabase, and AWS, and is heading to Base mainnet. Ricardo earned a seat in the Surge accelerator and a Builder Spotlight at ARCTALKS with Circle.
 
@@ -45,11 +45,11 @@ Two wins, one pivot, one week of scrapped work. Ricardo's advice for future part
 
 ## Rohan Jadhav: The Win Nobody Told Him About
 
-Rohan Jadhav, Yash Deshpande, and Rushi Patil were all twenty-one years old and in the final year of their Computer Science degree when they entered the Qubic Hack the Future Hackathon. They were building Brockn Code — a student-led startup — alongside their studies, and they wanted to test their skills on a global stage.
+Rohan Jadhav, Yash Deshpande, and Rushi Patil were all twenty-one years old and in the final year of their Computer Science degree when they entered the Qubic Hack the Future Hackathon. They were building Brockn Code, a student-led startup, alongside their studies, and they wanted to test their skills on a global stage.
 
 Coming from a Tier 3 college in India, Rohan had already participated in more than ten hackathons. He knew what it meant to compete against teams with more resources, more experience, and more institutional backing. The bet he made was a simpler one: that determination, teamwork, and solid execution could compete anyway.
 
-They built the Qubic Live Whale and Token Analytics Dashboard — a platform providing real-time insights into whale activity, token movements, and ecosystem trends within the Qubic network, making complex blockchain data accessible and actionable for everyday users.
+They built the Qubic Live Whale and Token Analytics Dashboard, a platform providing real-time insights into whale activity, token movements, and ecosystem trends within the Qubic network, making complex blockchain data accessible and actionable for everyday users.
 
 They finished. The hackathon ended. The winners were announced.
 
@@ -63,11 +63,9 @@ The win validated what Brockn Code was built on: the belief that innovation does
 
 [Brockn Code](https://lablab.ai/ai-hackathons/qubic-hack-the-future/brockn-code/qubic-live-whale-and-token-analytics-dashboard)
 
-{/* SLOT: Carolina Alvarez-Areces Miranda — LUNA AI story goes here once her full write-up and video arrive */}
-
 ## What These Three Share
 
-None of them won by executing the safe version of their idea. Jamsheer and Amal rebuilt their submission with four hours left. Ricardo threw away a full week of work and built something entirely different. Rohan bet that a student team from a Tier 3 college in India could compete on a global stage — and found out they had won days after everyone else did.
+None of them won by executing the safe version of their idea. Jamsheer and Amal rebuilt their submission with four hours left. Ricardo threw away a full week of work and built something entirely different. Rohan bet that a student team from a Tier 3 college in India could compete on a global stage and found out they had won days after everyone else did.
 
 The pattern is not coincidental. [AI hackathons](https://lablab.ai/ai-hackathons) compress the validation cycle in a way that almost nothing else does. You build, you demo, you get direct feedback from people with real expertise. What they found out, in different rooms and different cities, is that the right move under pressure is rarely the one that feels safe.
 

--- a/blog/en/lablab-hackathon-success-stories-part-3.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-3.mdx
@@ -1,7 +1,7 @@
 ---
 title: "AI Hackathon Success Stories (Part 3): Three Builders Who Bet on the Gap and Won"
 description: "AI hackathon success stories: three builders who made the decisive bet nobody else was willing to make: SentinelIQ, RSoft, and Brockn Code."
-image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/3801a09d-3a8f-49ed-15ea-30145e734200/public"
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/d89e499a-9332-43fc-830f-d44332855000/public"
 authorUsername: "stevekimoi"
 ---
 

--- a/blog/en/lablab-hackathon-success-stories-part-3.mdx
+++ b/blog/en/lablab-hackathon-success-stories-part-3.mdx
@@ -13,7 +13,7 @@ Jamsheer Jabbar had spent years inside trading fintechs watching the same failur
 
 At the Deriv AI Hackathon Dubai, hosted by the global trading platform that lived inside this exact problem every day, Jamsheer and his teammate Amal Jose set out to fix it. SentinelIQ is a dual-agent platform that connects data across six business domains: clients, finance, partners, operations, compliance, and competition. It turns that data into live insights, risk scores, and executive-ready recommendations without requiring an engineer to run it.
 
-The first agent, the Sentinel Autonomous Scanner, does not wait to be asked. It generates its own audit missions, scores risks on a zero to one hundred scale based on dollar exposure, velocity, and trend severity, and correlates patterns across all six domains simultaneously. The second agent handles natural language queries: anyone in the business can ask a question in plain English and receive intent classification, domain detection, SQL generation, and insight delivery in return. Results push to Slack in real time. After every scan, the platform produces an Executive Intelligence Brief: not a data dump, but a decision document.
+The first agent, the Sentinel Autonomous Scanner, does not wait to be asked. It generates its own audit missions, scores risks on a zero to one hundred scale based on dollar exposure, velocity, and trend severity, and correlates patterns across all six domains simultaneously. The second agent handles natural language queries: anyone in the business can ask a question in plain English and receive intent classification, domain detection, SQL generation, and insight delivery in return. Results push to Slack in real time. After every scan, the platform produces an Executive Intelligence Brief, a short recommendation document instead of a raw list of numbers.
 
 Then, midway through the event, they almost scrapped it.
 
@@ -49,7 +49,7 @@ Rohan Jadhav, Yash Deshpande, and Rushi Patil were all twenty-one years old and 
 
 Coming from a Tier 3 college in India, Rohan had already participated in more than ten hackathons. He knew what it meant to compete against teams with more resources, more experience, and more institutional backing. The bet he made was a simpler one: that determination, teamwork, and solid execution could compete anyway.
 
-They built the Qubic Live Whale and Token Analytics Dashboard, a platform providing real-time insights into whale activity, token movements, and ecosystem trends within the Qubic network, making complex blockchain data accessible and actionable for everyday users.
+They built the Qubic Live Whale and Token Analytics Dashboard, which tracks whale activity, token movements, and ecosystem trends on the Qubic network in real time.
 
 They finished. The hackathon ended. The winners were announced.
 


### PR DESCRIPTION
## Summary

- Adds Part 3 of the lablab hackathon success stories series
- Covers three builders: Jamsheer Jabbar & Amal Jose (SentinelIQ, Deriv AI Hackathon Dubai), Ricardo Pari (RSoft — two 1st-place wins at SURGE × OpenClaw and Agentic Commerce on Arc), and Rohan Jadhav (Brockn Code, Qubic Hack the Future)
- Unifying angle: builders who made the decisive bet nobody else in the room was willing to make — a 4-hour complete rebuild, scrapping a week of work, and a Tier 3 India student team going global
- A `{/* SLOT */}` comment marks where Carolina Alvarez-Areces Miranda's (LUNA AI) story will be added once her full write-up arrives; title/description will update from "Three" to "Four" at that point

## Test plan

- [ ] Verify frontmatter renders correctly (title, description, image, authorUsername)
- [ ] Confirm all three story links resolve on lablab.ai
- [ ] Confirm internal links to `/ai-hackathons` and `/events` work
- [ ] Check word count is within 800–1,500 range (currently 1,206)
- [ ] Confirm no marketing language ("powerful", "revolutionary", etc.)