### PR TITLE
Add demo video to Speechmatics call intelligence

### DIFF
--- a/tutorials/en/speechmatics-multilingual-call-intelligence-agent.mdx
+++ b/tutorials/en/speechmatics-multilingual-call-intelligence-agent.mdx
@@ -7,6 +7,10 @@ authorUsername: "stevekimoi"
 
 ## Introduction
 
+Watch the full multilingual call intelligence agent in action before diving in:
+
+<LiteYouTube videoId="cZC3b6C5_oc" containerClassName={"youtubeContainer"} />
+
 Speechmatics ships two features that, on their own, are well documented: real-time translation, which turns one audio stream into transcripts in [30+ languages simultaneously](https://docs.speechmatics.com/speech-to-text/features/translation), and Speech Intelligence, which adds summarization and sentiment on top of a transcript. What nobody has written up is what happens when you combine them into a single working build — a live call where an English conversation is transcribed, translated into five languages at once, and simultaneously summarized with a rolling sentiment read, all in one dashboard.
 
 Speechmatics is also a recurring partner technology at **AI hackathons** on lablab.ai, which makes this exact combination — real-time multilingual translation plus live call intelligence — a strong project idea for anyone entering an online AI hackathon that touches voice, agents, or multilingual support tooling. If you're looking for a hackathon to apply it in, browse [lablab.ai's global AI hackathons](https://lablab.ai/ai-hackathons).


### PR DESCRIPTION
## Summary
- Embeds the demo video (https://youtu.be/cZC3b6C5_oc) at the top of the Introduction section in the Speechmatics multilingual call intelligence tutorial (#1041), using the `LiteYouTube` component per repo convention.

## Test plan
- [x] Verify video renders correctly in the rendered MDX preview