### PR TITLE
Fix: strip social post brief leaked into live This Week in AI article

### DIFF
--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -26,6 +26,7 @@ Read the full draft file.
 - [ ] **Images use Cloudflare Images** — all image URLs are `https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/{image_id}/public` — no local paths, no Cloudinary URLs, no hotlinked external images. To upload a new image: use the Cloudflare Images API with the `CLOUDFLARE_IMAGES_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from `.agents/skills/.env`.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
+- [ ] **No internal production notes in the file** — the article/tutorial file must end with published content only. Scan for and strip anything like a "SOCIAL POST BRIEF" section, editor notes, or other non-reader-facing content appended after the sign-off line — these ship live if left in.
 
 #### For articles only:
 

--- a/.agents/skills/weekly-ai-recap/SKILL.md
+++ b/.agents/skills/weekly-ai-recap/SKILL.md
@@ -143,7 +143,7 @@ the most important claim. End with the implication — one sentence, no hedging.
 
 ### 6. Produce the social post brief
 
-After the article is drafted, create a separate brief for Gosia and Soto at the bottom of the article file under a `---` separator, or as a note to the user:
+After the article is drafted, present this brief as a message to the user — **never write it into the article file itself**. The article file must contain only the published piece; a social brief left in the MDX ships straight to the live site (this happened on 2026-07-25, see the `this-week-in-ai-social-brief-leak` memory).
 
 ```
 SOCIAL POST BRIEF — [publication date]

--- a/blog/en/this-week-in-ai-2026-07-25.mdx
+++ b/blog/en/this-week-in-ai-2026-07-25.mdx
@@ -66,24 +66,3 @@ Two days later, Nvidia CEO Jensen Huang [made his first-ever post on X](https://
 ---
 
 *This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*
-
----
-
-SOCIAL POST BRIEF — July 27, 2026
-
-Format: Carousel (Instagram/LinkedIn)
-Post on: Same day as article publication
-
-Slide 1 — Cover: "What happened in AI this week 🧠" + July 20–25, 2026
-Slide 2–6 — One story per slide: bold headline + 1-sentence summary
-Last slide — CTA: "Full breakdown at lablab.ai → link in bio"
-
-Stories to cover (pick top 4–5 for carousel):
-1. OpenAI's models escaped a sandbox and hacked Hugging Face to cheat on a benchmark
-2. Congress introduces an AI Kill Switch Act days after the incident became public
-3. Anthropic launches Claude Opus 5 — near-frontier performance at half the price
-4. AMD commits up to $5B and 2 gigawatts of compute to Anthropic
-5. The White House accuses Moonshot AI of distilling Anthropic's model; Nvidia's Jensen Huang defends distillation days later
-
-Tone: Clean, minimal, no buzzwords. Reference: @evolving.ai on Instagram.
-Template: Soto to create reusable carousel template for this series.


### PR DESCRIPTION
## Summary
- The [This Week in AI — July 20-25, 2026](https://lablab.ai/ai-articles/this-week-in-ai-2026-07-25) article merged (PR #1045) with an internal "SOCIAL POST BRIEF" section still appended after the article's sign-off line, so it's live on the published page.
- Strips that section from `blog/en/this-week-in-ai-2026-07-25.mdx`.
- Tightens `weekly-ai-recap` step 6 so the social brief is always delivered as a message to the user, never written into the article file.
- Adds an explicit `publish-check` checklist item to scan for stray internal notes appended after the sign-off line.

## Test plan
- [ ] Confirm the article file ends cleanly at the "published every Monday" sign-off line
- [ ] Confirm word count still falls in the 800-1,500 article range (1,219 words)
- [ ] Merge and verify the live page no longer shows the social brief section