### PR TITLE
Embed video walkthrough at top of AWS Kiro

### DIFF
--- a/tutorials/en/aws-kiro-hooks-steering-custom-agents-deep-dive.mdx
+++ b/tutorials/en/aws-kiro-hooks-steering-custom-agents-deep-dive.mdx
@@ -7,6 +7,10 @@ authorUsername: "stevekimoi"
 
 # Beyond the First App: Hooks, Steering, and Custom Agents in AWS Kiro
 
+Watch the full walkthrough before diving in:
+
+<LiteYouTube videoId="oEGNKIj1TmI" containerClassName={"youtubeContainer"} />
+
 Every Kiro tutorial you've probably seen ends at the same place: you write a spec, Kiro generates working code, credits roll. That's the demo. It's also where the interesting part of Kiro actually starts.
 
 This production-style setup is what separates a weekend prototype from something you can demo with confidence in **AI hackathons** — where judges care less about "it generated some code" than whether it holds up live. If you're prepping for an event, browse [lablab.ai's global AI hackathons](https://lablab.ai/ai-hackathons).


### PR DESCRIPTION
## Summary
- Adds a short "watch before you read" tagline and `<LiteYouTube>` embed (https://youtu.be/oEGNKIj1TmI) directly under the title of the AWS Kiro hooks/steering/custom agents tutorial
- Matches the existing embed pattern used in other tutorials (e.g. Speechmatics)

## Test plan
- [x] Verified `<LiteYouTube videoId="oEGNKIj1TmI" ... />` renders per the existing pattern used elsewhere in the repo
- [ ] Spot-check on lablab.ai staging/preview once merged