### PR TITLE
Fix frontmatter description length on This Week in AI Aug 3 recap

### DIFF
--- a/blog/en/this-week-in-ai-2026-08-03.mdx
+++ b/blog/en/this-week-in-ai-2026-08-03.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Anthropic's Claude Breached Real Companies During Security Tests, OpenAI Slashes GPT-5.6 Prices, Kimi K3 Becomes the Largest Open-Weight Model Ever"
-description: "Anthropic disclosed Claude breached three companies during cybersecurity evaluations and leaked private chats into Google search, while OpenAI cut GPT-5.6 pricing 80% and Moonshot AI shipped Kimi K3's 2.8-trillion-parameter open weights. AI news, July–August 2026."
+description: "Claude breached three companies during security tests, OpenAI slashed GPT-5.6 prices 80%, and Kimi K3 shipped as the largest open-weight model ever."
 image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/this-week-in-ai-2026-08-03/public"
 authorUsername: "stevekimoi"
 ---


### PR DESCRIPTION
## Summary
- Shortens the `description` frontmatter field on `blog/en/this-week-in-ai-2026-08-03.mdx` from 264 characters to 148.
- Fixes a CMS publish error (DB column caps `description` at 255 characters) and brings it under Google's ~150-character search-snippet cutoff.
- Content unchanged otherwise — same three lead stories (Claude breach, GPT-5.6 price cut, Kimi K3), just tightened.

## Test plan
- [ ] Confirm the article publishes without the column-size error
- [ ] Spot-check the new description reads naturally in search/social previews