### PR TITLE
Add tutorial-gap-scan skill, depth-check step for content-ideate and hackathon-tutorial

### DIFF
--- a/.agents/skills/content-ideate/SKILL.md
+++ b/.agents/skills/content-ideate/SKILL.md
@@ -32,11 +32,19 @@ After all searches, answer:
 
 Only proceed with an angle that passes: **"I could not find this written anywhere."** If everything is covered, reframe around the gap rather than retreading existing ground.
 
-### 4. Generate titles
+### 4. Depth check
+
+Passing the uniqueness check is not enough — a "first contact" angle (getting-started, hello-world, basic CRUD wiring) can be technically unique and still too shallow to be worth publishing, because it only restates what the tool's own quickstart already covers.
+
+Ask: does this angle stop where the official quickstart stops? If yes, push it into the tool's differentiating or advanced surface area — the features that separate it from competitors or from "autocomplete with extra steps" — rather than the wiring to get a first example running. Present the pushed-deeper version, not the first draft.
+
+Exception: if the brief explicitly targets a Beginner reader and an intro piece is the actual goal, shallow is correct — say so explicitly rather than defaulting to it silently.
+
+### 5. Generate titles
 
 Produce 3 options — beginner-friendly, outcome-focused, comparison/contrast. Avoid: "A Guide to X", "Everything About X", "The Ultimate X Tutorial".
 
-### 5. Present the brief
+### 6. Present the brief
 
 ```
 Type: [Article / Tutorial]
@@ -54,7 +62,7 @@ Suggested file path: [blog/en/slug.mdx or tutorials/en/slug/article.mdx]
 
 Wait for the user to confirm title and angle.
 
-### 6. Post to Notion
+### 7. Post to Notion
 
 Once confirmed, run:
 
@@ -70,7 +78,7 @@ python3 scripts/post_to_notion.py \
 
 Share the returned Notion URL with the user.
 
-### 7. Create a design request for Damian
+### 8. Create a design request for Damian
 
 Immediately after posting to Notion, create a cover image request in the design database so Damian can start work in parallel.
 

--- a/.agents/skills/hackathon-tutorial/SKILL.md
+++ b/.agents/skills/hackathon-tutorial/SKILL.md
@@ -69,7 +69,15 @@ After searching, answer:
 
 Only proceed with an angle that passes: **"I could not find this exact tutorial written anywhere."**
 
-### 4. Define what the tutorial builds
+### 4. Depth check
+
+Passing the uniqueness check is not enough — a "first contact" angle (getting-started, hello-world, minimal wiring to hit the API once) can be technically unique and still too shallow to be worth a full tutorial slot, because it only restates the partner's own quickstart.
+
+Ask: does this angle stop where the partner's official quickstart stops? If yes, push it into the partner tech's differentiating or advanced surface area — the features that separate it from a generic stack, not the wiring to call the API once — rather than presenting the first-contact version. Present the pushed-deeper version.
+
+Exception: if the hackathon page's target participant level is explicitly beginner-focused and an intro piece is the actual goal, shallow is correct — say so explicitly rather than defaulting to it silently.
+
+### 5. Define what the tutorial builds
 
 Specify the demo project in one concrete paragraph:
 
@@ -85,7 +93,7 @@ Estimated steps in the tutorial: [number]
 
 This section forces specificity before writing begins. If you cannot fill it in, the angle is not concrete enough — go back to step 2.
 
-### 5. Generate titles
+### 6. Generate titles
 
 Produce 3 title options. Requirements:
 - Outcome-first: lead with what the reader will have built, not the technology name
@@ -99,7 +107,7 @@ Option 2: [title]
 Option 3: [title]
 ```
 
-### 6. Present the full brief
+### 7. Present the full brief
 
 ```
 ─────────────────────────────────────────────
@@ -134,7 +142,7 @@ Suggested repo name: [kebab-case-repo-name]
 
 Wait for the user to confirm the title and angle before continuing.
 
-### 7. Post to Notion
+### 8. Post to Notion
 
 Once the user confirms, post to the Tasks & Action Items DB (`2cab4088-66ca-4d1f-aeb9-8fe29dafb470`):
 
@@ -159,7 +167,7 @@ Repo: [suggested repo name]
 
 Share the Notion URL with the user.
 
-### 8. Hand off
+### 9. Hand off
 
 Confirm to the user:
 - [ ] Hackathon page parsed

--- a/.agents/skills/tutorial-gap-scan/SKILL.md
+++ b/.agents/skills/tutorial-gap-scan/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: tutorial-gap-scan
+description: Scan lablab's hackathon technology partners against published tutorials to find coverage gaps — partners with zero tutorial coverage, and partners with only stale (not-this-year) coverage. Use when you don't have a specific source or hackathon page yet and want to find what to write about next. Outputs a ranked gap list and hands off to content-ideate or hackathon-tutorial.
+compatibility: Designed for Claude Code. Requires WebSearch/WebFetch. lablab.ai pages often return Cloudflare challenges to automated fetches — fall back to web search plus grepping this repo's tutorials/ and blog/en/ directories.
+---
+
+## When to use
+
+Run this skill first when the ask is open-ended — "what should we write next," "find us a tutorial gap," "what partners don't we cover yet" — and there is no source, idea, or hackathon page already in hand.
+
+Do NOT use this for a specific hackathon page already provided (use `hackathon-tutorial`) or a specific tweet/article/idea already in hand (use `content-ideate`). This skill's only job is finding the candidate; it does not generate titles, run the deep uniqueness check, or post to Notion — that's the next skill's job.
+
+---
+
+## Steps
+
+### 1. Gather the partner list
+
+Fetch `https://lablab.ai/ai-hackathons` for the hackathons in scope (default: current calendar year, or a range the user specifies).
+
+If the direct fetch is blocked (Cloudflare challenge/403 — common), fall back to:
+- Web search: `site:lablab.ai/event [year] hackathon`
+- Cross-check against any prior gap-scan results already in memory
+
+For each hackathon, extract the technology partner(s) sponsoring it.
+
+### 2. Gather existing coverage
+
+Fetch `https://lablab.ai/ai-tutorials`. If blocked, grep this repo instead:
+- `tutorials/` and `blog/en/` — search actual title/description/body content for each partner name, not just filenames. A partner can be mentioned in passing without a dedicated tutorial; only count real coverage.
+- For every match, note the publish year (from the filename date, frontmatter, or `git log` on the file).
+
+### 3. Cross-reference and classify
+
+For each partner technology:
+- **Net-new gap** — zero tutorial coverage anywhere
+- **Stale coverage** — tutorial(s) exist, but none published in the current calendar year
+- **Covered** — a tutorial published this year exists → drop from the list
+
+### 4. Filter for feasibility
+
+Before presenting, exclude partners that cannot actually be tutorial subjects, and say why:
+- Not yet publicly released — no public API/SDK access
+- Physical/hardware-bound — requires owning specific hardware with no cloud/simulator path
+
+Flag these explicitly rather than silently dropping them — a feasibility call can be wrong (e.g., a simulator or waitlist access might exist). Let the user confirm or override.
+
+### 5. Rank by urgency
+
+1. Partner has an active or upcoming hackathon (within ~2 weeks) — a gap-filling tutorial published during a live hackathon is far more valuable than one published after
+2. Net-new gaps rank above stale coverage
+3. Within a tier, rank by how many hackathons have featured that partner — more exposure means more reader demand
+
+### 6. Present the ranked list
+
+```
+NET-NEW GAPS (no tutorial coverage)
+1. [Partner] — featured in [N] hackathons, most recent [date]. [urgency note if any]
+2. ...
+
+STALE COVERAGE (tutorial exists, nothing published this year)
+1. [Partner] — [N] tutorials, most recent [year]. [urgency note if any]
+2. ...
+
+EXCLUDED (feasibility)
+- [Partner] — [reason: unreleased / hardware-bound / other]
+```
+
+Wait for the user to pick one or more partners. Do not proceed to research or drafting concepts yourself.
+
+### 7. Hand off
+
+- Partner tied to a specific live/upcoming hackathon page → hand off to `hackathon-tutorial` with that hackathon's URL
+- Otherwise → hand off to `content-ideate`, passing the partner name and gap classification (net-new vs stale) as the source/context
+
+## Gotchas
+
+- lablab.ai pages frequently return Cloudflare challenges to automated fetches — don't stall on a 403, go straight to the WebSearch + repo-grep fallback
+- "Stale coverage" is judged against the current calendar year, not a rolling 12 months — recompute the cutoff each time this skill runs, don't reuse a hardcoded year
+- A partner appearing in multiple hackathons is listed once; the hackathon count is only an urgency/demand signal, not a separate entry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,10 +23,11 @@ topics/           — Topic index pages
 
 ## Skills
 
-Six agent skills live in `.agents/skills/` and cover the full content lifecycle. Use them in order:
+Seven agent skills live in `.agents/skills/` and cover the full content lifecycle. Use them in order:
 
 | Skill | When to use |
 |-------|-------------|
+| [`tutorial-gap-scan`](.agents/skills/tutorial-gap-scan/SKILL.md) | When there's no source or hackathon page yet and the ask is open-ended ("what should we write next") — scans hackathon tech partners against published tutorials, finds net-new and stale coverage gaps, ranks by urgency. Hands off to hackathon-tutorial or content-ideate |
 | [`hackathon-tutorial`](.agents/skills/hackathon-tutorial/SKILL.md) | When you have a hackathon page (URL or pasted content) and need a tutorial concept — parses partners/tracks/timeline, finds the strongest angle, does a uniqueness check, outputs a ready-to-write brief. Run this first, before content-start |
 | [`content-ideate`](.agents/skills/content-ideate/SKILL.md) | When you have a source (tweet, article, raw idea) and want to turn it into a content concept — outputs working title + brief, hands off to content-start |
 | [`content-start`](.agents/skills/content-start/SKILL.md) | Before writing any new article or tutorial — runs uniqueness check, gathers sources, confirms angle, sets Notion task to In Progress |


### PR DESCRIPTION
## Summary
- New skill `.agents/skills/tutorial-gap-scan/SKILL.md`: scans lablab's hackathon technology partners against published tutorials to find net-new gaps (zero coverage) and stale coverage (covered, but nothing published this year), filters out infeasible partners (unreleased / hardware-bound), ranks by urgency, and hands off to `content-ideate` or `hackathon-tutorial`. This formalizes a step that's been run manually and inconsistently across several tutorial-ideation sessions.
- Adds a "Depth check" step to both `content-ideate` and `hackathon-tutorial`: passing the uniqueness check isn't sufficient if the angle only restates the tool's own quickstart — every concept run through these skills recently got sent back once for being too "hello world" before landing. This makes that push-deeper pass explicit instead of relying on manual pushback each time.
- Updates the skill table in `CLAUDE.md` to include the new skill, ahead of `hackathon-tutorial`/`content-ideate` in the recommended order.

## Test plan
- [ ] Run `tutorial-gap-scan` end-to-end on a real "what should we write next" ask and confirm the ranked gap list is useful
- [ ] Confirm the depth-check step doesn't cause `content-ideate`/`hackathon-tutorial` to reject genuinely appropriate beginner-level briefs