### PR TITLE
Add humanizer pass as a publish-check step

### DIFF
--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -26,6 +26,12 @@ Run the `humanizer` skill on the full prose body (frontmatter, code blocks, YAML
 
 Fix what the pass flags (em dashes used as parenthetical punctuation, filler phrases, forced triads, vague sourcing, chatbot artifacts, etc.) without changing any fact, number, name, date, or link. If a flagged pattern is actually the site's deliberate house style (e.g. this repo's consistent title-case section headings, or a recurring series sign-off), leave it and note why in the report rather than forcing a change for its own sake. It's fine for this step to find nothing to change — say so rather than editing for the sake of editing.
 
+Sentence-level tells (dashes, curly quotes, filler words) are the easy half of this check and checking only those produces false confidence — a piece can pass every line-level pattern and still read as AI-written at the structural level. Read the whole draft once specifically for these before signing off:
+- **Reflexive "moral of the story" tags** — a sentence at the end of a paragraph that explicitly states the takeaway ("The lesson stuck: ...", "That discipline is the only reason...", "a mistake that taught him to...") instead of trusting the reader to draw it from the facts already given. Cut these; the preceding facts should already carry the point.
+- **Mystery-box narration** — withholding what happened for a sentence ("something happened that had nothing to do with his code") before revealing it in the next. State it directly.
+- **Redundant recap conclusions** — a closing section that re-narrates each point already made in the body, rather than adding a real synthesis or a different level of abstraction. If the current piece has other installments in the same series, check their closing sections for the actual house pattern before assuming the draft's structure is normal.
+- **Uniform templating across parallel sections** — when a piece covers multiple similar subjects (people, products, releases), check whether each section leans on the identical rhetorical device (the same contrast construction in every headline, the same sentence shape closing every section). Some repetition is natural; identical scaffolding every time is a tell.
+
 ### 4. Run the checklist
 
 #### For both articles and tutorials:

--- a/.agents/skills/publish-check/SKILL.md
+++ b/.agents/skills/publish-check/SKILL.md
@@ -17,7 +17,16 @@ Ask the user (if not already clear):
 
 Read the full draft file.
 
-### 3. Run the checklist
+### 3. Run the humanizer pass
+
+Run the `humanizer` skill on the full prose body (frontmatter, code blocks, YAML, and link targets stay untouched — content only):
+
+- If `humanizer` appears in the Skill tool registry, invoke it directly in file mode on the draft.
+- If it doesn't (a fresh plugin install doesn't show up until the next session), read `SKILL.md` directly instead of skipping the step — check `~/.claude/plugins/cache/humanizer/humanizer/*/SKILL.md` first; if that's not present, fetch `https://raw.githubusercontent.com/blader/humanizer/main/SKILL.md` — and apply its rewrite process by hand.
+
+Fix what the pass flags (em dashes used as parenthetical punctuation, filler phrases, forced triads, vague sourcing, chatbot artifacts, etc.) without changing any fact, number, name, date, or link. If a flagged pattern is actually the site's deliberate house style (e.g. this repo's consistent title-case section headings, or a recurring series sign-off), leave it and note why in the report rather than forcing a change for its own sake. It's fine for this step to find nothing to change — say so rather than editing for the sake of editing.
+
+### 4. Run the checklist
 
 #### For both articles and tutorials:
 
@@ -27,6 +36,7 @@ Read the full draft file.
 - [ ] **No unverified stats** — any numbers or claims have a linked source in the text
 - [ ] **No marketing language** — scan for: "powerful", "revolutionary", "cutting-edge", "game-changing"
 - [ ] **No internal production notes in the file** — the article/tutorial file must end with published content only. Scan for and strip anything like a "SOCIAL POST BRIEF" section, editor notes, or other non-reader-facing content appended after the sign-off line — these ship live if left in.
+- [ ] **No AI-writing patterns** — covered by the humanizer pass in step 3
 
 #### For articles only:
 
@@ -48,21 +58,23 @@ Read the full draft file.
 - [ ] **Final output shown** — screenshot, terminal output, or demo of the working result
 - [ ] **File saved in** `tutorials/[slug]/article.md`
 
-### 4. Report results
+### 5. Report results
 
 List every checklist item with a pass/fail. For any failure:
 - Quote the specific line or section that has the problem
 - Suggest the fix
 
+Report the humanizer pass separately: what it changed (or that it found nothing to change), and any pattern it flagged that was deliberately left as house style.
+
 Do not mark the piece as done if any item fails.
 
-### 5. Update Notion
+### 6. Update Notion
 
 Once all checklist items pass:
 - Fetch the Notion task by title from DB `2cab4088-66ca-4d1f-aeb9-8fe29dafb470`
 - Update Status → `Done`
 - Add a note to the Notes field: `Draft complete. File: [path]. Checked: [today's date].`
 
-### 6. Confirm
+### 7. Confirm
 
 Report: "All checks passed. Notion task '[title]' set to Done."


### PR DESCRIPTION
## Summary
- publish-check now runs a humanizer pass (new step 3) before the checklist, removing AI-writing patterns (em dashes as parenthetical punctuation, filler phrases, forced triads, vague sourcing, chatbot artifacts) while preserving facts, links, and deliberate house style
- Added a corresponding checklist item and a reporting line for what the pass changed (or that it found nothing to change)
- Falls back to reading the humanizer plugin's SKILL.md directly (cache path, then GitHub) when the plugin isn't yet loaded into the current session's skill registry

## Test plan
- [ ] Run publish-check on a draft and confirm the humanizer step executes before the checklist
- [ ] Confirm it correctly no-ops on already-clean prose instead of forcing edits