### PR TITLE
Add This Week in AI recap for August 17-24, 2026

### DIFF
--- a/blog/en/this-week-in-ai-2026-08-24.mdx
+++ b/blog/en/this-week-in-ai-2026-08-24.mdx
@@ -1,0 +1,68 @@
+---
+title: "Anthropic's IPO Sprint, NVIDIA's $105B Ohio Bet, Google's Agent Protocol Handoff"
+description: "Anthropic moves toward an IPO that could outsize SpaceX's record debut, NVIDIA backs a $105 billion OpenAI data center, and Google hands A2A to a neutral foundation. This week in AI news for August 2026."
+image: "https://imagedelivery.net/K11gkZF3xaVyYzFESMdWIQ/this-week-in-ai-2026-08-24/public"
+authorUsername: "stevekimoi"
+---
+
+# Anthropic's IPO Sprint, NVIDIA's $105B Ohio Bet, Google's Agent Protocol Handoff
+
+*This Week in AI — August 17–24, 2026*
+
+This week the industry's biggest moves happened off the model leaderboard entirely. Anthropic edged toward a stock listing that could dwarf SpaceX's record debut, NVIDIA guaranteed OpenAI's next data center, and Google handed its agent protocol to a neutral foundation instead of guarding it. The story of the week isn't which model is smartest — it's who controls the capital and rails underneath it.
+
+## Key Takeaways
+
+- **Anthropic:** A public S-1 filing could land as soon as end of August, with investors reportedly eyeing a valuation that would top SpaceX's [$1.77 trillion IPO](https://unusualwhales.com/news/anthropic-public-s1-filing-august-2026). Expect every AI vendor pitch this fall to lean on "path to IPO" as a credibility signal.
+- **NVIDIA & OpenAI:** NVIDIA is backing up to $105 billion in financing for a new Ohio data center built for OpenAI, including a direct [$1.5 billion stake in SB Energy](https://www.axios.com/2026/08/17/openai-nvidia-ohio-data-center-sb-energy). Compute scarcity is now solved with vendor financing, not just cash.
+- **Etched:** The inference-chip startup [doubled its valuation to $21 billion](https://techcrunch.com/2026/08/18/etcheds-valuation-doubles-to-21b-in-a-month/) in under a month after Jane Street became its first paying customer. Specialized inference silicon just proved it can land real customers fast.
+- **Google:** A2A, Google's agent-to-agent protocol, joined Anthropic's MCP under the [Linux Foundation's Agentic AI Foundation](https://www.axios.com/2026/08/17/a2a-agentic-ai-foundation-open-ai-standards), which now counts AWS, Microsoft, and OpenAI as members. Builders can start treating agent interop as a standards question, not a lock-in bet.
+- **OpenAI:** ChatGPT ads went live across [31 European markets](https://openai.com/index/chatgpt-ads-expands-across-europe/), hitting free and Go-tier users under a GDPR consent model — the ad-supported playbook search and social already ran.
+
+---
+
+## Compute Gets Its Own Gold Rush
+
+### NVIDIA Bankrolls a $105 Billion Data Center for OpenAI
+
+NVIDIA is guaranteeing up to $105 billion in financing for a new SB Energy-built data center in Ohio, leased to OpenAI for 20 years, plus a direct $1.5 billion equity stake in SB Energy. Capacity comes online in phases starting 2028, supporting 35,000 construction jobs and 2,500 permanent roles, per [Axios](https://www.axios.com/2026/08/17/openai-nvidia-ohio-data-center-sb-energy). NVIDIA isn't just selling GPUs anymore — it's underwriting the buildings they sit in, locking OpenAI into NVIDIA hardware for the life of the lease.
+
+### Etched Doubles Its Valuation to $21 Billion in a Month
+
+Etched raised $700 million led by Jane Street — joined by Kleiner Perkins, Sequoia, and Tiger Global — weeks after a $300 million round backed by NVIDIA, pushing its valuation to $21 billion. Jane Street didn't just write the check, it [installed the first Etched-powered rack](https://techcrunch.com/2026/08/18/etcheds-valuation-doubles-to-21b-in-a-month/) in its own data center. Etched claims over $1 billion in customer contracts on hardware built purely for inference — proof that market alone can fund a $21 billion company.
+
+---
+
+## Frontier Labs Chase Revenue, Two Different Ways
+
+### Anthropic Edges Toward a Record-Breaking IPO
+
+Anthropic is preparing to publicly file its S-1 as soon as the end of August, following a confidential draft filed with the SEC in June and a $65 billion Series H that valued the company at $965 billion. Some investors are now [targeting an October IPO](https://unusualwhales.com/news/anthropic-public-s1-filing-august-2026) at a $2 trillion valuation — which would make it the largest public offering ever, ahead of SpaceX's June debut. Anthropic hasn't confirmed a date or valuation, but the direction is clear: AI lab funding is moving from private mega-rounds to public markets.
+
+### OpenAI Brings Ads to ChatGPT in Europe
+
+OpenAI started serving ads to Free and Go-tier ChatGPT users across 31 European countries on August 24, six months after the ad business launched as a US pilot. OpenAI says [targeting relies on explicit consent](https://openai.com/index/chatgpt-ads-expands-across-europe/) to satisfy GDPR, and that ads don't influence model answers or get sold to advertisers. Paid and enterprise tiers stay ad-free — pay, or become the product, same as every consumer platform before it.
+
+---
+
+## Frenemies and Ground Rules
+
+### Google Hands A2A to a Neutral Foundation
+
+Google's Agent2Agent protocol formally joined the Linux Foundation-backed Agentic AI Foundation, sitting alongside Anthropic's Model Context Protocol under shared, vendor-neutral governance. The foundation has [grown from 49 to over 250 members](https://www.axios.com/2026/08/17/a2a-agentic-ai-foundation-open-ai-standards) in under a year, with AWS, Anthropic, Microsoft, and OpenAI all signed on. A2A handles how agents discover and delegate to each other; MCP handles how they reach tools and data — together they're becoming the closest thing agentic AI has to a shared protocol stack.
+
+### Meta Is Quietly One of Microsoft's Biggest AI Customers
+
+Despite building its own Muse model family, Meta is spending hundreds of millions a year on Microsoft's Azure for AI compute and models, making it [one of Microsoft's largest AI customers](https://www.bloomberg.com/news/articles/2026-08-20/meta-has-quietly-become-one-of-microsoft-s-largest-ai-customers). Even labs racing to build frontier models in-house aren't willing to bet their entire compute pipeline on their own capacity — competitive rhetoric and infrastructure dependency are running on separate tracks.
+
+---
+
+## Quick Hits
+
+- **US–China AI policy:** Washington is drafting a letter telling roughly 35 partner nations in its Pax Silica coalition to choose between the US and China's rival AI bloc or risk exclusion, per [Reuters via CNBC](https://www.cnbc.com/2026/08/15/us-to-tell-allies-they-must-pick-sides-in-ai-race-with-china-reuters.html).
+- **AWS:** Web Search on Amazon Bedrock AgentCore [expanded to Europe and Asia Pacific](https://aws.amazon.com/about-aws/whats-new/2026/08/web-search-amazon-bedrock/), adding domain and publish-date filtering for agent grounding.
+- **SK Hynix:** The memory chipmaker announced a [$28.6 billion share buyback](https://www.bloomberg.com/news/articles/2026-08-19/sk-hynix-announces-28-6-billion-share-buy-back-on-ai-boom) starting August 20, citing record profits from AI memory (HBM) demand.
+
+---
+
+*This Week in AI is published every Monday by the [Lablab](https://lablab.ai) team.*


### PR DESCRIPTION
## Summary
- Weekly "This Week in AI" recap covering August 17–24, 2026
- Top stories: Anthropic's IPO prep, NVIDIA's $105B OpenAI Ohio data center backing, Etched's $700M raise, Google's A2A joining the Agentic AI Foundation, OpenAI's ChatGPT ads expanding to Europe, and Meta's Azure spend
- Branded cover image generated and uploaded to Cloudflare Images

## Test plan
- [ ] Frontmatter renders correctly (title, description, image, authorUsername)
- [ ] Cover image loads from Cloudflare Images
- [ ] All inline source links resolve
- [ ] Word count within range (1,116 words)