### PR TITLE
Add intro video to the Alpaca risk-managed trading agent

### DIFF
--- a/tutorials/en/alpaca-cli-mcp-risk-managed-trading-agent.mdx
+++ b/tutorials/en/alpaca-cli-mcp-risk-managed-trading-agent.mdx
@@ -7,6 +7,8 @@ authorUsername: "stevekimoi"
 
 ## Introduction
 
+<LiteYouTube videoId="XuHKLxB55lo" containerClassName={"youtubeContainer"} />
+
 Alpaca shipped two new agent-facing surfaces this year: a [Trading CLI](https://docs.alpaca.markets/us/docs/alpacas-cli) that turns the Trading API into explicit terminal commands with structured JSON output, and an [official MCP server](https://github.com/alpacahq/alpaca-mcp-server) that exposes those same trading and market-data capabilities as tools any MCP-aware assistant can call. Each is well documented on its own. What's missing is what happens when you actually combine them on one running agent: one interface for scheduled, unattended execution, and a second, separate interface for asking that same agent questions in plain English without touching its schedule.
 
 That combination is also exactly what the [Alpaca AI Trading Agents Hackathon on lablab.ai](https://lablab.ai/ai-hackathons/alpaca-ai-trading-agents-hackathon) is built around: participants are asked to build AI trading agents using Alpaca's Trading API, MCP server, and CLI together. If you're looking for an **online AI hackathon** to point a finished agent at, that one's the natural fit, and this tutorial's companion project is a submission-ready starting point for it.


### PR DESCRIPTION
## Summary
- Adds the intro video (https://youtu.be/XuHKLxB55lo) to `tutorials/en/alpaca-cli-mcp-risk-managed-trading-agent.mdx`, placed just below the title/H1, at the top of the Introduction section
- Verified the video ID resolves via YouTube's oEmbed API and its title matches this tutorial

## Test plan
- [x] `<LiteYouTube videoId="XuHKLxB55lo" .../>` follows this repo's existing embed convention
- [x] Video confirmed live and correctly titled via oEmbed check